### PR TITLE
feat(v1.7.0): rename context-guard → context-handoff; fix retired CI model IDs

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "superpowers-gstack",
   "description": "Routing, context management, and project setup for the Superpowers + GStack workflow",
-  "version": "1.6.1",
+  "version": "1.7.0",
   "author": {
     "name": "Kjetil Geirbo"
   }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "superpowers-gstack",
   "description": "Routing, context management, and project setup for the Superpowers + GStack workflow",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "author": {
     "name": "Kjetil Geirbo"
   }

--- a/.github/workflows/check-updates.yml
+++ b/.github/workflows/check-updates.yml
@@ -312,7 +312,7 @@ jobs:
           Output ONLY the file contents and markers, no markdown fences or commentary."""
 
           request = {
-              "model": "claude-sonnet-4-20250514",
+              "model": "claude-sonnet-4-6",
               "max_tokens": 32000,
               "messages": [{"role": "user", "content": user_content}]
           }

--- a/.github/workflows/self-repair.yml
+++ b/.github/workflows/self-repair.yml
@@ -111,7 +111,7 @@ jobs:
           Output ONLY file markers and content, no commentary."""
 
           request = {
-              "model": "claude-sonnet-4-20250514",
+              "model": "claude-sonnet-4-6",
               "max_tokens": 16000,
               "messages": [{"role": "user", "content": prompt}]
           }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## [1.7.0] - 2026-04-27
+
+### Added
+- **`/context-handoff` skill** — renamed from `/context-guard` to better describe what it does: writes a human-readable handoff file (`docs/superpowers/handoff.md`) in the project repo before `/clear` or `/compact`. Not the same as gstack's `/context-save` (which stores machine-local state in `~/.gstack/`) — this lives in the repo and works cross-machine without gstack installed.
+
+### Fixed
+- **GitHub Actions model ID** — both `check-updates.yml` and `self-repair.yml` used the retired `claude-sonnet-4-20250514` model ID, causing all CI API calls to fail. Updated to `claude-sonnet-4-6`.
+
+### Changed
+- **VERSIONS.md** — GStack bumped to v1.15.0.0 (dde5510), verified 2026-04-27.
+- All references to `/context-guard` updated to `/context-handoff` across CLAUDE.md, README.md, setup-routing, adapt, and the generated CLAUDE.md template.
+
 ## [1.6.1] - 2026-04-26
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## [1.6.1] - 2026-04-26
+
+### Fixed
+- **`CLAUDE.md` routing rule** — replaced the stale `→ invoke checkpoint` rule with explicit rules for `/context-save`, `/context-restore`, and `/context-guard`. The `/checkpoint` command was removed from gstack in plugin v1.4.0 but the routing rule was missed at the time.
+
+### Changed
+- **Routing tables synced with gstack v1.14.0.0** — added 14 new gstack skills to `setup-routing/SKILL.md`, `adapt/SKILL.md`, and `README.md` Quick Reference: `/design-consultation`, `/design-html`, `/design-shotgun`, `/devex-review`, `/guard`, `/landing-report`, `/open-gstack-browser`, `/pair-agent`, `/plan-devex-review`, `/plan-tune`, `/setup-browser-cookies`, `/setup-deploy`, `/setup-gbrain`, `/unfreeze`.
+- `VERSIONS.md` updated: GStack v1.4.0.0 → v1.14.0.0 (verified 2026-04-26).
+- `.update-state.json` refreshed (last successful check was 2026-04-06).
+
+### Notes for users
+- No behavior changes to existing routing rules.
+- gstack v1.x ships several internal behavior changes that don't affect plugin routing but are worth knowing about: workspace-aware `/ship` (auto-detects PR queue collisions), plan-mode review skills now run inline without an exit-and-rerun handshake, and the browser sidebar is now an interactive Claude Code REPL.
+
 ## [1.6.0] - 2026-04-22
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,7 +63,7 @@ For the update notification hook (optional, after cloning the repo):
 
 On session start or after /compact: if `docs/superpowers/handoff.md` exists and contains content, read it and present a one-line summary of where you left off. Then proceed normally — do not ask "ready to continue?". Clear the file (write empty string) immediately after presenting the summary.
 
-After /compact: if handoff.md does not contain `## Mode: auto`, ask the user once: "Context was compressed. Want me to activate auto context guard for this session? I'll keep handoff.md updated and suggest /clear when context gets heavy." If yes, invoke the context-guard skill.
+After /compact: if handoff.md does not contain `## Mode: auto`, ask the user once: "Context was compressed. Want me to activate auto context handoff for this session? I'll keep handoff.md updated and suggest /clear when context gets heavy." If yes, invoke the context-handoff skill.
 
 ## Skill conversation discipline
 
@@ -88,5 +88,5 @@ Key routing rules:
 - Architecture review → invoke plan-eng-review
 - End of day, switch project, save progress → invoke context-save
 - Resume previous session, restore state → invoke context-restore
-- Context long, before /clear, before /compact → invoke context-guard
+- Context long, before /clear, before /compact → invoke context-handoff
 - Code quality, health check → invoke health

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -86,6 +86,7 @@ Key routing rules:
 - Design system, brand → invoke design-consultation
 - Visual audit, design polish → invoke design-review
 - Architecture review → invoke plan-eng-review
-- End of day, switch project, checkpoint, git snapshot → invoke checkpoint
+- End of day, switch project, save progress → invoke context-save
+- Resume previous session, restore state → invoke context-restore
 - Context long, before /clear, before /compact → invoke context-guard
 - Code quality, health check → invoke health

--- a/README.md
+++ b/README.md
@@ -32,12 +32,12 @@ They never overlap. GStack focuses on *what roles review the work*. Superpowers 
 - **Claude Code Plugin** with four skills:
   - `/setup-routing` — Generates a tailored CLAUDE.md for new projects
   - `/adapt` — Adds routing to existing projects without losing your CLAUDE.md content
-  - `/context-guard` — Saves session state, auto-resumes after `/clear` or `/compact`, and proactively suggests context resets when sessions get long
+  - `/context-handoff` — Writes a human-readable handoff to `docs/superpowers/handoff.md` before `/clear` or `/compact`. Auto-resumes on next session start. Different from gstack's `/context-save` — this lives in the repo and works cross-machine.
   - `/pitfall-verification` — Final-check skill run after any PRD, spec, plan, or code artifact. Targeted check that typical pitfalls for that artifact type and domain (security, idempotency, contracts, edge cases, LLM output) actually do not apply. Two rounds max.
 - **[Appendix](appendix-reference.md)** — Skill internals, troubleshooting, and anti-patterns
 - **Automated update pipeline** — GitHub Actions keeps the plugin in sync when upstream frameworks change
 
-> **Tip:** In autocomplete, type `/setup-routing`, `/adapt`, or `/context-guard` — Claude Code matches on the skill name. The full prefixed form (e.g. `/superpowers-gstack:adapt`) also works.
+> **Tip:** In autocomplete, type `/setup-routing`, `/adapt`, or `/context-handoff` — Claude Code matches on the skill name. The full prefixed form (e.g. `/superpowers-gstack:adapt`) also works.
 
 ## Kickstart
 
@@ -94,7 +94,7 @@ This generates a CLAUDE.md with routing rules tailored to your project type, tec
 | Bug fix | `/superpowers:systematic-debugging` |
 | Code complete, ready for review | `/review` |
 | Ready to ship | `/ship` |
-| Long session, save state | `/context-guard` |
+| Long session, save state | `/context-handoff` |
 
 ## The Workflow
 
@@ -149,12 +149,12 @@ If review feedback needs code changes: `/superpowers:receiving-code-review` → 
 Long sessions degrade Claude's output quality — a problem known as context rot. [GSD](https://github.com/gsd-build/get-shit-done) solves this with a full orchestration layer, but that creates nesting issues when combined with Superpowers' subagent-driven development (three layers of orchestration). This plugin takes a lighter approach:
 
 **How it works:**
-1. After `/compact`, Claude asks if you want to activate auto context guard for the session
+1. After `/compact`, Claude asks if you want to activate auto context handoff for the session
 2. If yes, it keeps `docs/superpowers/handoff.md` updated as a living document — current task, decisions, next step
 3. When context gets heavy again, Claude suggests `/clear`
 4. After `/clear`, Claude automatically reads the handoff file, presents where you left off, and clears it — no "resume" command needed
 
-**Manual use:** Run `/context-guard` anytime to save state before a `/clear`.
+**Manual use:** Run `/context-handoff` anytime to save state before a `/clear`.
 
 No hooks, no orchestration overhead, no nesting. Just save and restore.
 
@@ -269,7 +269,7 @@ Review passed? → /qa → /cso → /ship
 | `/health` | Code quality dashboard |
 | `/context-save` | Save progress, save state |
 | `/context-restore` | Resume where left off |
-| `/context-guard` | Save session state before /clear |
+| `/context-handoff` | Write handoff to repo before /clear (cross-machine, no gstack required) |
 | `/careful` | Destructive command warnings |
 | `/freeze` | Restrict edits to one directory |
 | `/unfreeze` | Clear the freeze boundary mid-session |

--- a/README.md
+++ b/README.md
@@ -247,15 +247,23 @@ Review passed? → /qa → /cso → /ship
 | `/plan-ceo-review` | Validating scope and strategy |
 | `/plan-eng-review` | Locking architecture |
 | `/plan-design-review` | Validating design |
+| `/plan-devex-review` | Validating developer experience |
+| `/plan-tune` | Tune plan-skill question preferences (one-time, per-project) |
 | `/autoplan` | Chains all three reviews |
 | `/review` | Pre-merge code review |
 | `/qa <url>` | Browser-based testing |
 | `/cso` | Security audit |
 | `/design-review` | Visual audit |
+| `/design-consultation` | Design system from scratch |
+| `/design-shotgun` | Generate multiple design variants |
+| `/design-html` | Finalize design as production HTML/CSS |
+| `/devex-review` | Live developer experience audit |
 | `/investigate` | Bug root cause (QA/production) |
 | `/ship` | Create PR and deploy |
 | `/land-and-deploy` | Merge and verify |
 | `/canary` | Post-deploy monitoring |
+| `/landing-report` | Read-only PR queue + sibling-workspace dashboard |
+| `/setup-deploy` | Configure deploy platform (one-time) |
 | `/document-release` | Update docs |
 | `/retro` | Sprint retrospective |
 | `/health` | Code quality dashboard |
@@ -264,11 +272,17 @@ Review passed? → /qa → /cso → /ship
 | `/context-guard` | Save session state before /clear |
 | `/careful` | Destructive command warnings |
 | `/freeze` | Restrict edits to one directory |
+| `/unfreeze` | Clear the freeze boundary mid-session |
+| `/guard` | Full safety: `/careful` + `/freeze` combined |
 | `/browse` | Headless browser |
+| `/open-gstack-browser` | Launch GStack Browser (Chromium + sidebar) |
+| `/pair-agent` | Pair a remote AI agent with your browser |
+| `/setup-browser-cookies` | Import cookies for authenticated tests |
 | `/benchmark` | Performance regression detection |
 | `/benchmark-models` | Cross-model benchmark |
 | `/make-pdf` | Markdown to publication-quality PDFs |
 | `/learn` | Save cross-session learnings |
+| `/setup-gbrain` | Onboard cross-session memory (gbrain) |
 | `/codex` | OpenAI Codex CLI second opinion |
 
 ### Superpowers Commands

--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -4,7 +4,7 @@ This manual was last verified against these versions:
 
 | Component | Version | Date |
 |-----------|---------|------|
-| GStack | v1.14.0.0 (ed1e4be) | 2026-04-26 |
+| GStack | v1.15.0.0 (dde5510) | 2026-04-27 |
 | Superpowers | 5.0.7 | 2026-04-22 |
 | Claude Code | 2.1.114 | 2026-04-22 |
 

--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -4,7 +4,7 @@ This manual was last verified against these versions:
 
 | Component | Version | Date |
 |-----------|---------|------|
-| GStack | v1.4.0.0 (d0782c4) | 2026-04-22 |
+| GStack | v1.14.0.0 (ed1e4be) | 2026-04-26 |
 | Superpowers | 5.0.7 | 2026-04-22 |
 | Claude Code | 2.1.114 | 2026-04-22 |
 

--- a/docs/superpowers/plans/2026-04-26-gstack-v1.14-sync.md
+++ b/docs/superpowers/plans/2026-04-26-gstack-v1.14-sync.md
@@ -1,0 +1,495 @@
+# Sync superpowers-gstack with gstack v1.14.0.0 — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Bring superpowers-gstack v1.6.0 in sync with gstack v1.14.0.0 — fix one stale routing rule and surface 14 new gstack skills in all three routing surfaces (`CLAUDE.md`, `setup-routing/SKILL.md`, `adapt/SKILL.md`, `README.md`).
+
+**Architecture:** Pure documentation patch. Three routing surfaces and one CHANGELOG entry. No code, no scripts, no behavior changes. Bumps `plugin.json` to 1.6.1 (patch — bugfix + documentation sync).
+
+**Tech Stack:** Markdown only. Validation via `grep` checks (no automated test suite exists in this repo).
+
+---
+
+## Context for the engineer (assume zero prior context)
+
+**Repo:** `/Users/kjetilge/Developer/superpowers-gstack`. **All paths in this plan are relative to that repo root.** Run `cd /Users/kjetilge/Developer/superpowers-gstack` before starting.
+
+**Pre-flight: working tree must be clean.** Before Task 1, run `git status --short` and confirm only `.DS_Store` files appear (those are gitignored noise). If real uncommitted changes exist, STOP and ask the user — this plan creates a single coherent commit and shouldn't bury someone else's work-in-progress.
+
+**Pre-flight: gstack must be a git install.** Run `[ -d ~/.claude/skills/gstack/.git ] && echo OK || echo "STOP: gstack not git-installed"`. The plan reads commit SHAs from gstack via `git rev-parse`; vendored installs without `.git/` will fail Tasks 5 and 6.
+
+**Re-run behavior.** This plan is **not idempotent**. Re-running after a successful first pass will fail Task 1's Edit ("old_string not found" because the line was already fixed) and CHANGELOG/plugin.json edits will refuse because the version numbers are already bumped. Treat any "old_string not found" error on a second run as expected — verify with `git log -1` that the fix commit is already in place, then skip the plan.
+
+**What this plugin does:** Generates `CLAUDE.md` routing rules for new (`setup-routing`) or existing (`adapt`) projects so Claude Code knows when to invoke gstack skills. The routing tables in those two skill files plus the README Quick Reference are the user-visible surface that lists what gstack offers.
+
+**Source of truth for skill list:** `ls -d ~/.claude/skills/*/` on a machine with current gstack installed. Today (2026-04-26) gstack is at v1.14.0.0 and links 45 skills. The plugin's routing surfaces only know about ~32 of them. The plugin's auto-update GitHub Action exists but its state file (`.update-state.json`) hasn't run successfully since 2026-04-06 — this manual sync covers that gap.
+
+**Bug being fixed:** `CLAUDE.md` line 89 still says `→ invoke checkpoint`, but `/checkpoint` was renamed to `/context-save` + `/context-restore` in plugin v1.4.0 (2026-04-20). The CHANGELOG documents the rename; the routing rule was missed.
+
+**Skills to add (14):** `/design-consultation`, `/design-html`, `/design-shotgun`, `/devex-review`, `/guard`, `/landing-report`, `/open-gstack-browser`, `/pair-agent`, `/plan-devex-review`, `/plan-tune`, `/setup-browser-cookies`, `/setup-deploy`, `/setup-gbrain`, `/unfreeze`.
+
+**Skills explicitly NOT added** (and why):
+- `gstack` (umbrella browse skill — superseded by `/browse` in routing)
+- `gstack-upgrade` (meta — runs from anywhere, not project-scoped)
+- `connect-chrome` (backwards-compat symlink to `open-gstack-browser`)
+- `git-workflow-skill` (not part of gstack — appears to come from another plugin)
+
+**Skill descriptions** (canonical one-liners — used verbatim across all three surfaces for consistency):
+
+| Skill | One-liner | Routing trigger phrase |
+|---|---|---|
+| `/design-consultation` | Design system from scratch (DESIGN.md, fonts, colors, motion) | "design system", "brand guidelines" |
+| `/design-html` | Finalize design as production-quality HTML/CSS | "build the design", "code the mockup" |
+| `/design-shotgun` | Generate multiple AI design variants and pick one | "explore designs", "show me options" |
+| `/devex-review` | Live developer experience audit (tests onboarding, docs, CLI) | "DX audit", "test the developer experience" |
+| `/guard` | `/careful` + `/freeze` combined (full safety mode) | "guard mode", "lock it down" |
+| `/landing-report` | PR queue + sibling-workspace dashboard (read-only) | "what's in the queue", "landing status" |
+| `/open-gstack-browser` | Launch GStack Browser (Chromium + sidebar extension) | "open gstack browser", "launch chrome" |
+| `/pair-agent` | Pair a remote AI agent with your browser | "pair agent", "share my browser" |
+| `/plan-devex-review` | Developer experience review in plan mode | "DX review", "API design review" |
+| `/plan-tune` | Tune plan-skill question preferences | "tune plan questions" |
+| `/setup-browser-cookies` | Import cookies into headless browse session | "import cookies", "authenticate the browser" |
+| `/setup-deploy` | Configure deploy platform for `/land-and-deploy` | "setup deploy", "configure deployment" |
+| `/setup-gbrain` | Onboard cross-session memory (gbrain) — PGLite or Supabase | "set up gbrain", "cross-session memory" |
+| `/unfreeze` | Clear the `/freeze` boundary | "unfreeze", "remove edit lock" |
+
+---
+
+## Task 1: Fix the stale `/checkpoint` routing rule in CLAUDE.md
+
+**Files:**
+- Modify: `CLAUDE.md:89`
+
+- [ ] **Step 1: Verify the current stale line exists**
+
+Run: `sed -n '89p' CLAUDE.md`
+
+Expected output (exact):
+```
+- End of day, switch project, checkpoint, git snapshot → invoke checkpoint
+```
+
+If the line differs, STOP and ask the user — the file may have changed since this plan was written.
+
+- [ ] **Step 2: Replace the stale rule with two correct rules**
+
+Use Edit tool with `old_string`:
+```
+- End of day, switch project, checkpoint, git snapshot → invoke checkpoint
+- Context long, before /clear, before /compact → invoke context-guard
+```
+
+`new_string`:
+```
+- End of day, switch project, save progress → invoke context-save
+- Resume previous session, restore state → invoke context-restore
+- Context long, before /clear, before /compact → invoke context-guard
+```
+
+Rationale: `/checkpoint` no longer exists in gstack — it was split into `/context-save` (proactive snapshot) and `/context-restore` (resume). `/context-guard` (the plugin's own skill) stays as the higher-level orchestrator. All three are distinct user intents.
+
+- [ ] **Step 3: Verify no other `checkpoint` references remain that imply it's a live command**
+
+Run: `grep -n 'checkpoint' CLAUDE.md README.md skills/*/SKILL.md appendix-reference.md`
+
+Expected: only matches inside CHANGELOG.md (historical) — no live routing rules. If grep finds anything in the listed files, STOP and read the context.
+
+---
+
+## Task 2: Add the 14 missing skills to `README.md` Quick Reference
+
+**Files:**
+- Modify: `README.md` (Quick Reference table around lines 250–280, plus optional `/context-guard` section nearby)
+
+- [ ] **Step 1: Locate the GStack Quick Reference table**
+
+Run: `grep -n '^| `/' README.md | head -40`
+
+Identify the GStack section block (between the `/office-hours` row and the row before the `/superpowers:*` rows start). It lives roughly at lines 240–280 — confirm exact line numbers before editing.
+
+- [ ] **Step 2: Insert the 14 new skill rows in topic order**
+
+Insert the rows in their correct topic sections (not as an undifferentiated dump at the bottom). Use Edit tool with multiple targeted edits, each anchored to an existing row.
+
+After the row `| `/plan-design-review` | Validating design |`:
+```
+| `/plan-devex-review` | Validating developer experience |
+| `/plan-tune` | Tune plan-skill question preferences |
+```
+
+After the row `| `/design-review` | Visual audit |`:
+```
+| `/design-consultation` | Design system from scratch |
+| `/design-shotgun` | Generate multiple design variants |
+| `/design-html` | Finalize design as production HTML/CSS |
+| `/devex-review` | Live developer experience audit |
+```
+
+After the row `| `/canary` | Post-deploy monitoring |`:
+```
+| `/landing-report` | PR queue + sibling-workspace dashboard |
+| `/setup-deploy` | Configure deploy platform (one-time) |
+```
+
+After the row `| `/freeze` | Restrict edits to one directory |`:
+```
+| `/unfreeze` | Clear the freeze boundary |
+| `/guard` | Full safety: `/careful` + `/freeze` combined |
+```
+
+After the row `| `/browse` | Headless browser |`:
+```
+| `/open-gstack-browser` | Launch GStack Browser (Chromium + sidebar) |
+| `/pair-agent` | Pair a remote AI agent with your browser |
+| `/setup-browser-cookies` | Import cookies for authenticated tests |
+```
+
+After the row `| `/learn` | Save cross-session learnings |`:
+```
+| `/setup-gbrain` | Onboard cross-session memory (gbrain) |
+```
+
+- [ ] **Step 3: Verify all 14 new rows landed in README**
+
+Run: `grep -cE '^\| `/(design-consultation|design-html|design-shotgun|devex-review|guard|landing-report|open-gstack-browser|pair-agent|plan-devex-review|plan-tune|setup-browser-cookies|setup-deploy|setup-gbrain|unfreeze)`' README.md`
+
+Expected: `14`
+
+If less than 14, identify the missing rows and re-add them.
+
+---
+
+## Task 3: Add the 14 missing skills to `skills/setup-routing/SKILL.md`
+
+**Files:**
+- Modify: `skills/setup-routing/SKILL.md` (skill evaluation tables, lines ~78–146)
+
+- [ ] **Step 1: Locate the section breaks**
+
+Run: `grep -n '^| `/' skills/setup-routing/SKILL.md | head -80`
+
+The file has multiple "When to evaluate" tables grouped by phase: Phase 1 (planning/spec), Phase 2 (implementation), Phase 3 (QA/review), Phase 4 (ship/deploy), Long-running, Safety/utility. Insert each new skill into its correct phase table.
+
+- [ ] **Step 2: Add Phase 1 (Planning) entries**
+
+Find the row `| `/plan-design-review` | Projects with UI/UX components |` and insert AFTER it:
+```
+| `/plan-devex-review` | Projects with developer-facing surfaces (APIs, CLIs, SDKs, libraries) |
+| `/plan-tune` | Tune plan-skill question preferences (one-time, per-project) |
+```
+
+- [ ] **Step 3: Add Phase 3 (QA / Review) entries**
+
+Find the row `| `/design-review` | Projects with visual UI — catches spacing, alignment, inconsistencies |` and insert AFTER it:
+```
+| `/design-consultation` | New projects defining a design system from scratch (creates DESIGN.md) |
+| `/design-shotgun` | When you want multiple design variants to compare before committing |
+| `/design-html` | When you have an approved design and need production HTML/CSS |
+| `/devex-review` | Developer-facing projects — live audit of onboarding flow, docs, CLI help |
+```
+
+- [ ] **Step 4: Add Phase 4 (Ship / Deploy) entries**
+
+Find the row `| `/canary` | Projects with production monitoring needs |` and insert AFTER it:
+```
+| `/landing-report` | Read-only PR queue + sibling-workspace dashboard (workspace-aware ship) |
+| `/setup-deploy` | One-time: configure deploy platform (Fly.io, Vercel, Render, etc.) for `/land-and-deploy` |
+```
+
+- [ ] **Step 5: Add Memory / configuration entries**
+
+Find the row `| `/learn` | Long-running projects (> 2 weeks) — saves cross-session learnings |` and insert AFTER it:
+```
+| `/setup-gbrain` | Long-running projects wanting cross-session memory (PGLite local or Supabase) |
+```
+
+- [ ] **Step 6: Add Safety / utility entries**
+
+Find the row `| `/freeze` | Monorepos or projects where edits should be restricted TO a specific directory (allow-list, not block-list) |` and insert AFTER it:
+```
+| `/unfreeze` | Clear the `/freeze` boundary mid-session without ending the session |
+| `/guard` | Production / shared-infra work — combines `/careful` warnings with `/freeze` directory lock |
+```
+
+- [ ] **Step 7: Add Browser / utility entries**
+
+Find the row `| `/browse` | Projects needing headless browser interaction beyond QA |` and insert AFTER it:
+```
+| `/open-gstack-browser` | Projects wanting a visible AI-controlled Chromium with live activity feed |
+| `/pair-agent` | When pairing a remote AI agent with your browser session |
+| `/setup-browser-cookies` | One-time: import cookies for authenticated `/qa` and `/browse` testing |
+```
+
+- [ ] **Step 8: Verify all 14 new skill rows landed**
+
+Run: `grep -cE '^\| `/(design-consultation|design-html|design-shotgun|devex-review|guard|landing-report|open-gstack-browser|pair-agent|plan-devex-review|plan-tune|setup-browser-cookies|setup-deploy|setup-gbrain|unfreeze)`' skills/setup-routing/SKILL.md`
+
+Expected: `14`
+
+---
+
+## Task 4: Mirror the changes into `skills/adapt/SKILL.md`
+
+**Files:**
+- Modify: `skills/adapt/SKILL.md` (skill evaluation tables, lines ~86–146)
+
+CLAUDE.md line 16 in `setup-routing/SKILL.md` says: `<!-- Keep in sync with skills/adapt/SKILL.md dependency + directory checks -->`. The two files have parallel routing tables that must stay aligned.
+
+- [ ] **Step 1: Verify table structure matches setup-routing**
+
+Run: `diff <(grep '^| `/' skills/setup-routing/SKILL.md) <(grep '^| `/' skills/adapt/SKILL.md)`
+
+Expected: identical output (both files should have the same `/`-rows in the same order). If they differ before this task starts, STOP and resolve the existing drift first.
+
+- [ ] **Step 2: Apply the same 14 insertions as Task 3**
+
+Repeat steps 2–7 from Task 3, applied to `skills/adapt/SKILL.md` instead of `skills/setup-routing/SKILL.md`. Use the exact same anchor rows and insertion content.
+
+- [ ] **Step 3: Re-verify the two files stay aligned**
+
+Run: `diff <(grep '^| `/' skills/setup-routing/SKILL.md) <(grep '^| `/' skills/adapt/SKILL.md)`
+
+Expected: identical output. If `diff` shows anything, the two files have diverged — fix the divergence before continuing.
+
+- [ ] **Step 4: Verify all 14 new skill rows landed in adapt/SKILL.md**
+
+Run: `grep -cE '^\| `/(design-consultation|design-html|design-shotgun|devex-review|guard|landing-report|open-gstack-browser|pair-agent|plan-devex-review|plan-tune|setup-browser-cookies|setup-deploy|setup-gbrain|unfreeze)`' skills/adapt/SKILL.md`
+
+Expected: `14`
+
+---
+
+## Task 5: Update `VERSIONS.md` to reflect gstack v1.14.0.0
+
+**Files:**
+- Modify: `VERSIONS.md`
+
+- [ ] **Step 1: Get the current gstack short SHA into a shell variable**
+
+Run:
+```bash
+GSTACK_SHORT_SHA=$(cd ~/.claude/skills/gstack && git rev-parse --short HEAD)
+echo "Short SHA: $GSTACK_SHORT_SHA"
+```
+
+If this prints empty or errors (e.g. gstack not a git repo), STOP — the plan assumes global-git install and the `git rev-parse` must succeed.
+
+- [ ] **Step 2: Apply the substitution with the Edit tool — do NOT use `sed` here**
+
+`sed` is unsafe for this row: the markdown table uses `|` as a column separator, which collides with `sed`'s default and most alternative delimiters and creates fragile escaping. Use the Edit tool directly with `old_string`:
+```
+| GStack | v1.4.0.0 (d0782c4) | 2026-04-22 |
+```
+
+For `new_string`, **literally type the value step 1 printed** — never type the placeholder text `$GSTACK_SHORT_SHA` or `<SHA from step 1>`. Example: if step 1 printed `Short SHA: ed1e4be`, then `new_string` is exactly:
+```
+| GStack | v1.14.0.0 (ed1e4be) | 2026-04-26 |
+```
+
+- [ ] **Step 3: Verify the file**
+
+Run: `grep -E '^\| GStack' VERSIONS.md`
+
+Expected: the line shows `v1.14.0.0 (<7-char hex SHA>)` and date `2026-04-26`. The angle-bracket text `<SHA from step 1>` must NOT appear — if it does, you typed the placeholder instead of substituting; redo step 2.
+
+---
+
+## Task 6: Update `.update-state.json`
+
+**Files:**
+- Modify: `.update-state.json`
+
+- [ ] **Step 1: Get the full commit SHA + Claude Code version, with safe fallbacks**
+
+Run:
+```bash
+GSTACK_SHA=$(cd ~/.claude/skills/gstack && git rev-parse HEAD 2>/dev/null || echo "")
+CLAUDE_VER=$(claude --version 2>/dev/null | head -1 | awk '{print $1}' || echo "")
+NOW=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+echo "SHA: $GSTACK_SHA"
+echo "Claude: $CLAUDE_VER"
+echo "Now: $NOW"
+```
+
+If `GSTACK_SHA` is empty, STOP — the plan assumes global-git install. If `CLAUDE_VER` is empty, fall back to the previous value: read it from the existing file with `jq -r .claude_code_version .update-state.json` and use that — do NOT write an empty string there because `check-updates.sh:53` treats empty as "first run" and skips the version-changed warning.
+
+- [ ] **Step 2: Rewrite `.update-state.json` programmatically using `jq` — no placeholders**
+
+Run (substitutes the variables from step 1 directly, never use angle-bracket text):
+```bash
+jq -n \
+  --arg sha "$GSTACK_SHA" \
+  --arg claude "$CLAUDE_VER" \
+  --arg now "$NOW" \
+  '{gstack_commit: $sha, claude_code_version: $claude, superpowers_hash: "", last_check: $now}' \
+  > .update-state.json
+```
+
+Leave `superpowers_hash` empty — `check-updates.sh` populates it on next run, and an empty value is the documented "skip first-time-warning" sentinel (see `check-updates.sh:69`).
+
+- [ ] **Step 3: Verify it's valid JSON with the expected shape**
+
+Run:
+```bash
+jq -e '.gstack_commit | length == 40' .update-state.json && \
+jq -e '.claude_code_version | length > 0' .update-state.json && \
+jq -e '.last_check | startswith("2026-04-26")' .update-state.json && \
+echo "OK"
+```
+
+Expected: `OK`. If any check fails, the file is malformed — re-run step 2.
+
+---
+
+## Task 7: Add a CHANGELOG entry for v1.6.1
+
+**Files:**
+- Modify: `CHANGELOG.md`
+
+- [ ] **Step 1: Insert the new entry at the top (after the `# Changelog` header)**
+
+Use Edit tool with `old_string`:
+```
+# Changelog
+
+## [1.6.0] - 2026-04-22
+```
+
+`new_string`:
+```
+# Changelog
+
+## [1.6.1] - 2026-04-26
+
+### Fixed
+- **`CLAUDE.md` routing rule** — replaced the stale `→ invoke checkpoint` rule with explicit rules for `/context-save`, `/context-restore`, and `/context-guard`. The `/checkpoint` command was removed from gstack in plugin v1.4.0 but the routing rule was missed at the time.
+
+### Changed
+- **Routing tables synced with gstack v1.14.0.0** — added 14 new gstack skills to `setup-routing/SKILL.md`, `adapt/SKILL.md`, and `README.md` Quick Reference: `/design-consultation`, `/design-html`, `/design-shotgun`, `/devex-review`, `/guard`, `/landing-report`, `/open-gstack-browser`, `/pair-agent`, `/plan-devex-review`, `/plan-tune`, `/setup-browser-cookies`, `/setup-deploy`, `/setup-gbrain`, `/unfreeze`.
+- `VERSIONS.md` updated: GStack v1.4.0.0 → v1.14.0.0 (verified 2026-04-26).
+- `.update-state.json` refreshed (last successful check was 2026-04-06).
+
+### Notes for users
+- No behavior changes to existing routing rules.
+- gstack v1.x ships several internal behavior changes that don't affect plugin routing but are worth knowing about: workspace-aware `/ship` (auto-detects PR queue collisions), plan-mode review skills now run inline without an exit-and-rerun handshake, and the browser sidebar is now an interactive Claude Code REPL.
+
+## [1.6.0] - 2026-04-22
+```
+
+- [ ] **Step 2: Verify the entry rendered correctly**
+
+Run: `head -20 CHANGELOG.md`
+
+Expected: `## [1.6.1] - 2026-04-26` is the topmost version entry; v1.6.0 follows below.
+
+---
+
+## Task 8: Bump `plugin.json` to 1.6.1
+
+**Files:**
+- Modify: `.claude-plugin/plugin.json`
+
+- [ ] **Step 1: Replace the version field**
+
+Use Edit tool with `old_string`:
+```
+  "version": "1.6.0",
+```
+
+`new_string`:
+```
+  "version": "1.6.1",
+```
+
+- [ ] **Step 2: Verify**
+
+Run: `jq -r .version .claude-plugin/plugin.json`
+
+Expected: `1.6.1`
+
+---
+
+## Task 9: Final integration check + commit
+
+**Files:**
+- (No file changes — verification only, then `git commit`)
+
+- [ ] **Step 1: Confirm all stale `checkpoint` routing references are gone**
+
+Run: `grep -nE 'invoke checkpoint|→ checkpoint|/checkpoint\b' CLAUDE.md README.md skills/*/SKILL.md appendix-reference.md`
+
+Expected: no matches. (Matches inside CHANGELOG.md are historical and stay.)
+
+- [ ] **Step 2: Confirm all 14 new skills appear in all three routing surfaces**
+
+Run:
+```bash
+for f in README.md skills/setup-routing/SKILL.md skills/adapt/SKILL.md; do
+  count=$(grep -cE '/(design-consultation|design-html|design-shotgun|devex-review|guard|landing-report|open-gstack-browser|pair-agent|plan-devex-review|plan-tune|setup-browser-cookies|setup-deploy|setup-gbrain|unfreeze)\b' "$f")
+  echo "$f: $count mentions"
+done
+```
+
+Expected: each file has at least 14 mentions (one per skill, possibly more if a skill is referenced in prose too).
+
+- [ ] **Step 3: Confirm setup-routing and adapt routing tables are still in lockstep**
+
+Run: `diff <(grep '^| `/' skills/setup-routing/SKILL.md) <(grep '^| `/' skills/adapt/SKILL.md)`
+
+Expected: empty output (no differences).
+
+- [ ] **Step 4: Stage and commit**
+
+```bash
+cd /Users/kjetilge/Developer/superpowers-gstack
+git add CLAUDE.md README.md skills/setup-routing/SKILL.md skills/adapt/SKILL.md VERSIONS.md .update-state.json CHANGELOG.md .claude-plugin/plugin.json
+git status
+```
+
+Verify: only the 8 files above are staged. No `.DS_Store`, no other unrelated files.
+
+```bash
+git commit -m "$(cat <<'EOF'
+fix(v1.6.1): sync routing tables with gstack v1.14.0.0
+
+Fixes a stale /checkpoint routing rule in CLAUDE.md (was renamed to
+/context-save + /context-restore in v1.4.0 but the routing rule was
+missed). Adds 14 new gstack skills to setup-routing, adapt, and the
+README Quick Reference: design-consultation, design-html, design-shotgun,
+devex-review, guard, landing-report, open-gstack-browser, pair-agent,
+plan-devex-review, plan-tune, setup-browser-cookies, setup-deploy,
+setup-gbrain, unfreeze.
+
+VERSIONS.md updated to GStack v1.14.0.0 (verified 2026-04-26).
+.update-state.json refreshed (last successful check was 2026-04-06).
+
+No behavior changes to existing routing rules.
+EOF
+)"
+```
+
+- [ ] **Step 5: Verify the commit landed cleanly**
+
+Run: `git log --oneline -1 && git status`
+
+Expected: top commit is the one we just made; working tree clean (apart from `.DS_Store` if present).
+
+- [ ] **Step 6: (Optional) Push and propagate to the marketplace cache**
+
+If the user wants the marketplace cache (`~/.claude/plugins/cache/paretofilm-plugins/superpowers-gstack/1.6.0/`) to pick up the new version, they need to push to GitHub and then run `/plugin update superpowers-gstack` (or wait for Claude Code's auto-update). Push is NOT done in this plan — ask the user before pushing.
+
+---
+
+## Self-Review Checklist (run by the planner, not a subagent)
+
+- [x] **Spec coverage:** Every conflict identified in the investigation is addressed: stale routing rule (Task 1), 14 missing skills × 3 surfaces (Tasks 2–4), version metadata drift (Tasks 5–6), changelog + version bump (Tasks 7–8), final verification + commit (Task 9).
+
+- [x] **Placeholder scan:** No "TBD", no "implement later", no "add error handling", no abstract "similar to Task N". Every Edit shows the exact old_string and new_string. Every command shows expected output.
+
+- [x] **Type / name consistency:** All 14 skill names match the gstack-linked skills inventory (`ls -d ~/.claude/skills/*/`) verbatim. The list `/design-consultation|design-html|...|unfreeze` is identical in Tasks 2, 3, 4, and 9 — verification regex stays in lockstep with insertions.
+
+- [x] **Section anchors are real:** Each "Find the row X and insert AFTER it" anchor was verified to exist in the current files via `grep` during investigation. If anchors have shifted (e.g., another PR landed), the engineer is told to STOP and confirm.
+
+- [x] **Plan-vs-spec alignment:** The version bump is 1.6.1 (patch) because plugin behavior is unchanged — only documentation and one routing-rule bugfix. If a reviewer prefers 1.7.0 (minor — "added 14 skills feels like a feature"), update Task 8's `new_string` and Task 7's header accordingly. The user can override at execution time.
+
+- [x] **Reversibility:** Single commit, easy to `git revert`. No file deletions, no schema changes, no external API calls.

--- a/skills/adapt/SKILL.md
+++ b/skills/adapt/SKILL.md
@@ -105,6 +105,10 @@ Use the same evaluation tables as `setup-routing` to determine which Superpowers
 | `/plan-ceo-review` | Projects with strategic decisions or significant scope |
 | `/plan-eng-review` | Projects needing architecture decisions |
 | `/plan-design-review` | Projects with UI/UX components |
+| `/design-consultation` | New projects defining a design system from scratch (creates DESIGN.md) |
+| `/design-shotgun` | When you want multiple design variants to compare before committing |
+| `/plan-devex-review` | Projects with developer-facing surfaces (APIs, CLIs, SDKs, libraries) |
+| `/plan-tune` | Tune plan-skill question preferences (one-time, per-project) |
 | `/autoplan` | When all three plan reviews are relevant — chains them automatically |
 
 **GStack skills — Phase 3 (Review & QA):**
@@ -116,6 +120,8 @@ Use the same evaluation tables as `setup-routing` to determine which Superpowers
 | `/qa-only <url>` | Same, but report-only (no auto-fixes) |
 | `/cso` | Projects handling auth, user data, payments, or external APIs. For security-critical features, run BEFORE `/review` |
 | `/design-review` | Projects with visual UI — catches spacing, alignment, inconsistencies |
+| `/design-html` | When you have an approved design and need production HTML/CSS |
+| `/devex-review` | Developer-facing projects — live audit of onboarding flow, docs, CLI help |
 | `/investigate` | Bugs discovered AFTER Phase 2 — in QA, staging, or production. Do NOT use during Phase 2 implementation (use `/superpowers:systematic-debugging` instead) |
 
 **GStack skills — Phase 4 (Ship & Monitor):**
@@ -125,9 +131,12 @@ Use the same evaluation tables as `setup-routing` to determine which Superpowers
 | `/ship` | Projects using git with feature branches and PRs |
 | `/land-and-deploy` | Projects with CI/CD deployment pipelines |
 | `/canary` | Projects with production monitoring needs |
+| `/landing-report` | Read-only PR queue + sibling-workspace dashboard (workspace-aware ship) |
+| `/setup-deploy` | One-time: configure deploy platform (Fly.io, Vercel, Render, etc.) for `/land-and-deploy` |
 | `/document-release` | Projects with documentation to maintain |
 | `/retro` | Team projects with regular sprint cadence |
 | `/learn` | Long-running projects (> 2 weeks) — saves cross-session learnings |
+| `/setup-gbrain` | Long-running projects wanting cross-session memory (PGLite local or Supabase) |
 | `/health` | Projects with existing linting, type checking, or test suites |
 | `/make-pdf` | Projects needing publication-quality documentation or reports |
 
@@ -137,7 +146,12 @@ Use the same evaluation tables as `setup-routing` to determine which Superpowers
 |---|---|
 | `/careful` | Projects where destructive commands are risky (production DBs, shared infra) |
 | `/freeze` | Monorepos or projects where edits should be restricted TO a specific directory (allow-list, not block-list) |
+| `/unfreeze` | Clear the `/freeze` boundary mid-session without ending the session |
+| `/guard` | Production / shared-infra work — combines `/careful` warnings with `/freeze` directory lock |
 | `/browse` | Projects needing headless browser interaction beyond QA |
+| `/open-gstack-browser` | Projects wanting a visible AI-controlled Chromium with live activity feed |
+| `/pair-agent` | When pairing a remote AI agent with your browser session |
+| `/setup-browser-cookies` | One-time: import cookies for authenticated `/qa` and `/browse` testing |
 | `/context-guard` | Long implementation sessions, projects using SDD, or any multi-step workflow |
 | `/context-save` | Save progress and working state |
 | `/context-restore` | Resume where you left off |

--- a/skills/adapt/SKILL.md
+++ b/skills/adapt/SKILL.md
@@ -37,7 +37,7 @@ Do NOT proceed until both frameworks are present.
 > ```
 > Then run `/superpowers-gstack:adapt` again.
 
-**Version check:** This skill is version **1.6.0**. If the project's CLAUDE.md contains a version marker (`<!-- superpowers-gstack: X.Y.Z -->`) with an older version, inform the user that routing and session rules will be updated to the current version as part of this adaptation.
+**Version check:** This skill is version **1.7.0**. If the project's CLAUDE.md contains a version marker (`<!-- superpowers-gstack: X.Y.Z -->`) with an older version, inform the user that routing and session rules will be updated to the current version as part of this adaptation.
 
 ## Process
 

--- a/skills/adapt/SKILL.md
+++ b/skills/adapt/SKILL.md
@@ -152,7 +152,7 @@ Use the same evaluation tables as `setup-routing` to determine which Superpowers
 | `/open-gstack-browser` | Projects wanting a visible AI-controlled Chromium with live activity feed |
 | `/pair-agent` | When pairing a remote AI agent with your browser session |
 | `/setup-browser-cookies` | One-time: import cookies for authenticated `/qa` and `/browse` testing |
-| `/context-guard` | Long implementation sessions, projects using SDD, or any multi-step workflow |
+| `/context-handoff` | Long implementation sessions, projects using SDD, or any multi-step workflow |
 | `/context-save` | Save progress and working state |
 | `/context-restore` | Resume where you left off |
 | `/benchmark` | Projects with performance monitoring needs |
@@ -209,7 +209,7 @@ Apply the changes identified in Step 4. Follow these rules strictly:
   ```
   ## Session Continuity
   On session start or after /compact: if `docs/superpowers/handoff.md` exists and contains content, read it and present a one-line summary of where you left off. Then proceed normally — do not ask "ready to continue?". Clear the file (write empty string) immediately after presenting the summary.
-  After /compact: if handoff.md does not contain `## Mode: auto`, ask the user once: "Context was compressed. Want me to activate auto context guard for this session? I'll keep handoff.md updated and suggest /clear when context gets heavy." If yes, invoke the context-guard skill.
+  After /compact: if handoff.md does not contain `## Mode: auto`, ask the user once: "Context was compressed. Want me to activate auto context guard for this session? I'll keep handoff.md updated and suggest /clear when context gets heavy." If yes, invoke the context-handoff skill.
   ```
 
 **Structure setup:**

--- a/skills/context-handoff/SKILL.md
+++ b/skills/context-handoff/SKILL.md
@@ -1,17 +1,19 @@
 ---
-name: context-guard
-description: Context hygiene — saves work state and monitors session length. Invoke to save state, or auto-activated after compact.
+name: context-handoff
+description: Write a human-readable handoff file in the repo before /clear or /compact. Different from /context-save (gstack) — this writes to docs/superpowers/handoff.md for cross-machine and post-clear continuity.
 ---
 
-# Context Guard
+# Context Handoff
 
-Lightweight context hygiene inspired by GSD. Prevents context rot without adding orchestration overhead.
+Writes a human-readable session handoff to `docs/superpowers/handoff.md` in the project repo. Use this before `/clear` or `/compact` to capture where you left off.
+
+**Not the same as `/context-save`:** `/context-save` (gstack) stores machine-local session state in `~/.gstack/projects/` and is restored by `/context-restore`. This skill writes a Markdown file directly into the repo — readable by anyone, on any machine, without gstack installed.
 
 ## When this skill activates
 
 - User says "context getting long", "about to clear", "save before clear"
 - CLAUDE.md sensor triggers after /compact (user opts in to auto-modus)
-- User explicitly invokes /context-guard
+- User explicitly invokes /context-handoff
 
 ## Save state
 
@@ -50,7 +52,7 @@ Lightweight context hygiene inspired by GSD. Prevents context rot without adding
 
 ## Auto-modus (activated after compact)
 
-When the user opts in to auto context guard after a compact trigger:
+When the user opts in to auto context handoff after a compact trigger:
 
 1. **Append `## Mode: auto` to handoff.md** immediately. This marker tells the CLAUDE.md sensor not to re-ask after subsequent compacts.
 

--- a/skills/setup-routing/SKILL.md
+++ b/skills/setup-routing/SKILL.md
@@ -148,7 +148,7 @@ Think through each GStack skill, organized by phase:
 | `/open-gstack-browser` | Projects wanting a visible AI-controlled Chromium with live activity feed |
 | `/pair-agent` | When pairing a remote AI agent with your browser session |
 | `/setup-browser-cookies` | One-time: import cookies for authenticated `/qa` and `/browse` testing |
-| `/context-guard` | Long implementation sessions, projects using SDD, or any multi-step workflow |
+| `/context-handoff` | Long implementation sessions, projects using SDD, or any multi-step workflow |
 | `/context-save` | Save progress and working state |
 | `/context-restore` | Resume where you left off |
 | `/benchmark` | Projects with performance monitoring needs |
@@ -219,7 +219,7 @@ This project uses Superpowers + GStack. Each owns a distinct phase:
 
 On session start or after /compact: if `docs/superpowers/handoff.md` exists and contains content, read it and present a one-line summary of where you left off. Then proceed normally — do not ask "ready to continue?". Clear the file (write empty string) immediately after presenting the summary.
 
-After /compact: if handoff.md does not contain `## Mode: auto`, ask the user once: "Context was compressed. Want me to activate auto context guard for this session? I'll keep handoff.md updated and suggest /clear when context gets heavy." If yes, invoke the context-guard skill.
+After /compact: if handoff.md does not contain `## Mode: auto`, ask the user once: "Context was compressed. Want me to activate auto context handoff for this session? I'll keep handoff.md updated and suggest /clear when context gets heavy." If yes, invoke the context-handoff skill.
 
 ### Session Management
 - `/clear` when transitioning between GStack and Superpowers phases

--- a/skills/setup-routing/SKILL.md
+++ b/skills/setup-routing/SKILL.md
@@ -101,6 +101,10 @@ Think through each GStack skill, organized by phase:
 | `/plan-ceo-review` | Projects with strategic decisions or significant scope |
 | `/plan-eng-review` | Projects needing architecture decisions |
 | `/plan-design-review` | Projects with UI/UX components |
+| `/design-consultation` | New projects defining a design system from scratch (creates DESIGN.md) |
+| `/design-shotgun` | When you want multiple design variants to compare before committing |
+| `/plan-devex-review` | Projects with developer-facing surfaces (APIs, CLIs, SDKs, libraries) |
+| `/plan-tune` | Tune plan-skill question preferences (one-time, per-project) |
 | `/autoplan` | When all three plan reviews are relevant — chains them automatically |
 
 **Phase 3 — Review & QA:**
@@ -112,6 +116,8 @@ Think through each GStack skill, organized by phase:
 | `/qa-only <url>` | Same, but report-only (no auto-fixes) |
 | `/cso` | Projects handling auth, user data, payments, or external APIs. For security-critical features, run BEFORE `/review` |
 | `/design-review` | Projects with visual UI — catches spacing, alignment, inconsistencies |
+| `/design-html` | When you have an approved design and need production HTML/CSS |
+| `/devex-review` | Developer-facing projects — live audit of onboarding flow, docs, CLI help |
 | `/investigate` | Bugs discovered AFTER Phase 2 — in QA, staging, or production. Do NOT use during Phase 2 implementation (use `/superpowers:systematic-debugging` instead) |
 
 **Phase 4 — Ship & Monitor:**
@@ -121,9 +127,12 @@ Think through each GStack skill, organized by phase:
 | `/ship` | Projects using git with feature branches and PRs |
 | `/land-and-deploy` | Projects with CI/CD deployment pipelines |
 | `/canary` | Projects with production monitoring needs |
+| `/landing-report` | Read-only PR queue + sibling-workspace dashboard (workspace-aware ship) |
+| `/setup-deploy` | One-time: configure deploy platform (Fly.io, Vercel, Render, etc.) for `/land-and-deploy` |
 | `/document-release` | Projects with documentation to maintain |
 | `/retro` | Team projects with regular sprint cadence |
 | `/learn` | Long-running projects (> 2 weeks) — saves cross-session learnings |
+| `/setup-gbrain` | Long-running projects wanting cross-session memory (PGLite local or Supabase) |
 | `/health` | Projects with existing linting, type checking, or test suites |
 | `/make-pdf` | Projects needing publication-quality documentation or reports |
 
@@ -133,7 +142,12 @@ Think through each GStack skill, organized by phase:
 |---|---|
 | `/careful` | Projects where destructive commands are risky (production DBs, shared infra) |
 | `/freeze` | Monorepos or projects where edits should be restricted TO a specific directory (allow-list, not block-list) |
+| `/unfreeze` | Clear the `/freeze` boundary mid-session without ending the session |
+| `/guard` | Production / shared-infra work — combines `/careful` warnings with `/freeze` directory lock |
 | `/browse` | Projects needing headless browser interaction beyond QA |
+| `/open-gstack-browser` | Projects wanting a visible AI-controlled Chromium with live activity feed |
+| `/pair-agent` | When pairing a remote AI agent with your browser session |
+| `/setup-browser-cookies` | One-time: import cookies for authenticated `/qa` and `/browse` testing |
 | `/context-guard` | Long implementation sessions, projects using SDD, or any multi-step workflow |
 | `/context-save` | Save progress and working state |
 | `/context-restore` | Resume where you left off |

--- a/skills/setup-routing/SKILL.md
+++ b/skills/setup-routing/SKILL.md
@@ -39,7 +39,7 @@ Do NOT proceed until both frameworks are present.
 
 **Important:** If the project already has a `CLAUDE.md` file with existing content, STOP and suggest the user runs `/superpowers-gstack:adapt` instead — it preserves existing content while adding routing.
 
-**Version:** This skill writes version **1.6.0** into the CLAUDE.md version marker.
+**Version:** This skill writes version **1.7.0** into the CLAUDE.md version marker.
 
 ## Process
 


### PR DESCRIPTION
## Summary
- Renames `/context-guard` → `/context-handoff` — old name overlapped with gstack's `/context-save`; new name describes the action (writes `docs/superpowers/handoff.md` to the project repo for cross-machine continuity)
- Fixes retired model ID `claude-sonnet-4-20250514` → `claude-sonnet-4-6` in `check-updates.yml` and `self-repair.yml` — this was the root cause of all failed self-repair CI runs (API returned 404 before any logic ran)
- Syncs routing tables with gstack v1.14→v1.15 (v1.6.1 fix, included in this branch)

## Test plan
- [ ] Merge to main
- [ ] Trigger `check-updates.yml` manually via Actions tab to verify model ID fix
- [ ] Confirm `/context-handoff` skill is listed and invocable; `/context-guard` is gone

🤖 Generated with [Claude Code](https://claude.com/claude-code)