### PR TITLE
feat(v1.9.0): /macos-native-review — HIG-citation-grounded skill for macOS specs

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "superpowers-gstack",
   "description": "Routing, context management, and project setup for the Superpowers + GStack workflow",
-  "version": "1.8.1",
+  "version": "1.9.0",
   "author": {
     "name": "Kjetil Geirbo"
   }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [1.9.0] - 2026-04-28
+
+### Added
+- **`/macos-native-review` skill** — Apple-native conformance gate for macOS PRDs, specs, and implementation plans. Walks 12 HIG-grounded categories (vocabulary, control choices, keyboard shortcuts, semantic colors, sheets/popovers/alerts, animation timing, privileged operations, accessibility, menu bar, app lifecycle, dock icon behavior, App menu) and cites `developer.apple.com/design/human-interface-guidelines/...` for every finding via WebFetch. Phase 0 self-check rejects non-macOS artifacts (returns `N/A` for iOS-only or non-Apple projects). `PROVISIONAL` fallback when the HIG site is unreachable — never silently substitutes training-data recall for verified citations. Sequential after `/pitfall-verification` and `/quality-review`: that pair asks *"will this work?"* and *"will this feel good?"*; this asks *"is this Apple-native?"*. Sibling skills (`ios-native-review`, `windows-native-review`, `material-design-review`) deferred as IDEAS.md backlog entries with consistent template.
+
+### Changed
+- `setup-routing` and `adapt` version markers bumped to 1.9.0.
+- IDEAS.md: removed the `macos-native-review` proposal entry (skill shipped); added three sibling stubs (`ios-native-review`, `windows-native-review`, `material-design-review`) using the same Gap/Scope/Method/Differentiation/Status template.
+
 ## [1.8.1] - 2026-04-28
 
 ### Changed

--- a/IDEAS.md
+++ b/IDEAS.md
@@ -1,36 +1,94 @@
 # Backlog — proposed skills
 
-Notes on potential future skills, gathered during real review work. Each entry explains the GAP (what existing skills miss), the SCOPE (what the skill would do), and the OBSERVED NEED (when it would have been useful).
+Notes on potential future skills, gathered during real review work. Each entry follows a consistent template:
+
+- **Gap.** What existing skills miss.
+- **Scope.** What the skill would do.
+- **Method.** How it works (citation grounding, output format, mechanics).
+- **Differentiation.** Why it's not duplicating an existing skill.
+- **Status.** Deferred / shipped / in progress.
+
+When a skill ships, its entry moves to the "Shipped" section below with the commit reference. Active backlog entries above; shipped record below.
 
 ---
 
-## `macos-native-review` (proposed 2026-04-28)
+## `ios-native-review` (proposed 2026-04-28, deferred)
 
-**Gap.** `quality-review` covers premium-app feel in general terms (silent failures, loading states, empty states, native conventions, animations). It mentions native conventions but does NOT validate specific UI claims against Apple Human Interface Guidelines. `pitfall-verification` checks for bugs. Neither catches "this app smells non-native because the spec uses non-Apple vocabulary, the wrong control type for the surface, or missing macOS-standard keyboard shortcuts."
+**Gap.** Same gap as the (now-shipped) `macos-native-review` had on the macOS side: existing review skills (`pitfall-verification`, `quality-review`) don't validate iOS UI claims against Apple Human Interface Guidelines for iOS specifically. iOS HIG paths and surfaces differ from macOS — touch-first interaction, navigation paradigm (tab bar / navigation stack vs window-based), modal patterns (sheet detents, full-screen presentation), Dynamic Island, gesture conventions.
 
-**Scope.** Validate a macOS app spec or implementation against Apple HIG, specifically:
+**Scope.** Validate an iOS app spec or implementation plan against Apple HIG-iOS, specifically:
 
-- **Vocabulary:** does copy use Apple-canonical verbs (`Apply`/`Replace`/`Save`/`Done`/`Cancel`) and noun choices (Apple says "System Settings", not "Tweaks"; "Sidebar", not "Navigation Pane"; "Sheet", not "Modal Dialog")?
-- **Control choices:** is the chosen control HIG-correct for the surface? (e.g. `Picker` vs `Segmented Control` vs `TabView`; `Sheet` vs `Popover` vs `Alert`; toolbar buttons vs inline buttons)
-- **Keyboard shortcuts:** are macOS-standard shortcuts present? (`⌘W` to dismiss, `⌘.` to cancel, `⌘1`–`⌘9` for tab toggles, `⌘↩` for primary action in sheets, Space for expand/collapse)
-- **Semantic colors:** are status indicators using the right Apple semantic colors and not hardcoded? Does dark-mode story exist?
-- **Sheet / window behavior:** modal vs non-modal, dismissable, resizable — HIG-compliant?
-- **Animation timing:** is `.spring(response: 0.35, dampingFraction: 0.85)` aligned with Apple defaults, or is it just "feels good" guesswork?
-- **Privileged ops, files-in-home-dir, sandbox boundaries:** is the design HIG-aligned for sudo / sensitive operations?
-- **Accessibility:** are VoiceOver labels, Dynamic Type, and contrast considered?
+- **Touch targets** — 44×44pt minimum, hit-area conventions
+- **Navigation paradigm** — tab bar vs navigation stack vs split view; large titles; `.navigationBarTitleDisplayMode`
+- **Modal presentation** — sheet detents (`.presentationDetents`), full-screen cover, popover (iPad), `.presentationDragIndicator`
+- **Gesture conventions** — swipe-to-go-back, edge gestures, pull-to-refresh framing
+- **Status bar / safe area / Dynamic Island** — content respect for system surfaces
+- **Keyboard handling** — `.keyboardType`, `.textContentType`, return-key actions, dismissal
+- **Haptics** — appropriate haptic feedback for confirmation, selection, error
+- **Accessibility** — VoiceOver rotor support, Dynamic Type up to AX5, Reduce Motion
+- **App lifecycle** — scene-based architecture, background tasks, state restoration
+- **App Store / TestFlight conventions** — privacy nutrition labels framing, review-prompt timing
 
-**Method.** WebFetch against `developer.apple.com/design/human-interface-guidelines/<topic>` for each UI element claim, then mark each spec section ✓ / ⚠️ / ✗ with the HIG quote that supports the verdict. Should ground assertions in citations rather than the model's training data, since HIG evolves.
+**Method.** Same as `macos-native-review`: WebFetch against `developer.apple.com/design/human-interface-guidelines/<topic>` (iOS sub-paths), severity-tiered findings (CRITICAL / SIGNIFICANT / POLISH), strict per-finding citations, `PROVISIONAL` fallback. Phase 0 detects iOS signals (`UIKit`, `SwiftUI` with iOS deployment target, `UIViewController`, etc.).
 
-**Output format.** Same severity-tiered structure as `quality-review` (Critical / Significant / Polish) but every finding cites a specific HIG page URL.
-
-**Observed need.** During Phase E spec work for SwiftConfig (a native macOS SwiftUI app aimed at "premium feel"), all four review lenses already in the project — self-check, pitfall-verification × 3, quality-review, codex-consult × 4 — shipped a SHIP-READY spec that none of them had validated against actual Apple HIG. The user explicitly asked "burde vi ta en review til? i så fall hva slags?" and the gap that emerged was: nothing in our toolbox validates UI vocabulary, control choices, or keyboard conventions against Apple's published guidelines. We did the review manually (WebFetch + spec walk-through) but it should be a first-class skill for any macOS/iOS app project.
-
-**Differentiation from existing skills:**
-- `quality-review` = "would this feel premium?" (cross-platform, principle-based)
+**Differentiation.**
+- `quality-review` = "would this feel premium?" (cross-platform)
 - `pitfall-verification` = "would this work?" (bug hunt)
-- `codex-consult` = adversarial second opinion (independent model)
-- `macos-native-review` = "is this Apple-native?" (HIG-citation-grounded, platform-specific)
+- `macos-native-review` = "is this Apple-native on Mac?"
+- `ios-native-review` = "is this iOS-native?" (touch-first, navigation paradigm, modal detents)
 
-**Adjacent skills to consider:** `ios-native-review`, `windows-native-review`, `material-design-review` (Android) — same shape, different style guide. Could share infrastructure (severity tiers, citation format) via a parent `platform-native-review` skill.
+**Status.** Deferred — no observed need yet. Pick up when a real iOS spec review surfaces the gap.
 
-**When to invoke.** After a spec or implementation plan that touches platform-specific UI surfaces. Same trigger position as `quality-review` — between pitfall-verification and writing-plans.
+---
+
+## `windows-native-review` (proposed 2026-04-28, deferred)
+
+**Gap.** Existing review skills don't validate Windows app UI claims against Microsoft Fluent Design / WinUI 3 conventions. Windows-specific surfaces — taskbar, system tray, Win11 corner radius, mica/acrylic materials, command bar conventions — are absent from cross-platform `quality-review`.
+
+**Scope.** Validate a Windows app spec or implementation plan against Microsoft Fluent Design + WinUI 3 conventions, specifically:
+
+- **Vocabulary** — Microsoft-canonical verbs and noun choices
+- **Control choices** — `CommandBar` vs `MenuBar`, `Flyout` vs `Dialog`, `NavigationView` vs custom
+- **Keyboard shortcuts** — Windows-standard (`Ctrl+W`, `Ctrl+,` for settings, `Alt+F4`, F1 for help)
+- **Materials** — Mica vs Acrylic vs SolidBackground; when each applies
+- **Win11 corner radius** — 8px on windows, dynamic on controls
+- **Taskbar / system tray** — taskbar icon behavior, jump lists, system tray menu conventions
+- **Theme** — light/dark/auto with system, accent color respect
+- **Accessibility** — Narrator support, high-contrast theme, focus visuals
+- **Window management** — snap layouts, multi-window, restore
+
+**Method.** WebFetch against `learn.microsoft.com/en-us/windows/apps/design/...` (Fluent Design and WinUI 3 docs). Same severity tiers and citation discipline as `macos-native-review`. Phase 0 detects Windows signals (`.csproj` with `TargetFramework` net8.0-windows, `Microsoft.UI.Xaml`, `WinUI`, etc.).
+
+**Differentiation.** Same shape as `macos-native-review` but Windows-platform; uses Microsoft docs as the source of truth instead of Apple HIG.
+
+**Status.** Deferred — no observed need. Likely longer wait than `ios-native-review` given current project portfolio's Apple lean.
+
+---
+
+## `material-design-review` (proposed 2026-04-28, deferred)
+
+**Gap.** Existing review skills don't validate Android app UI claims against Material Design 3 (Google's design system). Android-specific surfaces — Material You dynamic color, motion specs, type scale, density — are absent from cross-platform `quality-review`.
+
+**Scope.** Validate an Android app spec or implementation plan against Material Design 3, specifically:
+
+- **Vocabulary** — Material-canonical labels (e.g. "Compose" vs "New", "Send" vs "Submit")
+- **Components** — `FloatingActionButton`, `BottomNavigation`, `NavigationDrawer`, `TopAppBar` variants, `BottomSheet`
+- **Dynamic color (Material You)** — `colorScheme` adapts to wallpaper; explicit theming for elements that should not adapt
+- **Motion specs** — Material easing curves (`emphasized`, `standard`), durations (`short`/`medium`/`long`)
+- **Type scale** — display, headline, title, body, label — using Material's named styles
+- **Density** — touch target sizes (48dp minimum), padding tokens
+- **Accessibility** — TalkBack support, contrast tokens, large-text-mode
+- **Edge-to-edge** — gesture insets, system bars handling
+- **App bar / scrolling behavior** — collapsing toolbars, tonal elevation on scroll
+
+**Method.** WebFetch against `m3.material.io/...` (Material Design 3 docs). Same severity tiers and citation discipline as `macos-native-review`. Phase 0 detects Android signals (`build.gradle` with Android plugin, `androidx.compose.*` imports, `.kt` Android-tagged files).
+
+**Differentiation.** Same shape as `macos-native-review` but Android-platform; uses Material Design 3 as the source of truth.
+
+**Status.** Deferred — no observed need.
+
+---
+
+## Shipped
+
+- `macos-native-review` — shipped in v1.9.0 (2026-04-28). See `skills/macos-native-review/SKILL.md`.

--- a/README.md
+++ b/README.md
@@ -29,12 +29,13 @@ They never overlap. GStack focuses on *what roles review the work*. Superpowers 
 
 ## What's Included
 
-- **Claude Code Plugin** with five skills:
+- **Claude Code Plugin** with six skills:
   - `/setup-routing` — Generates a tailored CLAUDE.md for new projects
   - `/adapt` — Adds routing to existing projects without losing your CLAUDE.md content
   - `/context-handoff` — Writes a human-readable handoff to `docs/superpowers/handoff.md` before `/clear` or `/compact`. Auto-resumes on next session start. Different from gstack's `/context-save` — this lives in the repo and works cross-machine.
   - `/pitfall-verification` — Final-check skill run after any PRD, spec, plan, or code artifact. Targeted check that typical pitfalls for that artifact type and domain (security, idempotency, contracts, edge cases, LLM output) actually do not apply. Two rounds max.
   - `/quality-review` — Perceived-quality gate run after a PRD, spec, or implementation plan, before implementation begins. Hunts pitfalls that make a product feel cheap or broken even when it technically works (silent failures, missing loading/empty states, error recovery, state drift, animations, AI output, sudo flows). Complementary to `/pitfall-verification`: that one asks "will this work?", this one asks "will this feel good?".
+  - `/macos-native-review` — Apple-native conformance gate for macOS PRDs, specs, and plans. 12 HIG-citation-grounded categories: vocabulary, control choices, keyboard shortcuts, semantic colors, sheets/popovers/alerts, animation timing, privileged operations, accessibility, menu bar, app lifecycle, dock behavior, App menu. Every finding cites a `developer.apple.com` HIG page via WebFetch. Phase 0 self-check rejects non-macOS artifacts. Complementary to `/pitfall-verification` ("will this work?") and `/quality-review` ("will this feel good?") — this asks "is this Apple-native?".
 - **[Appendix](appendix-reference.md)** — Skill internals, troubleshooting, and anti-patterns
 - **Automated update pipeline** — GitHub Actions keeps the plugin in sync when upstream frameworks change
 

--- a/skills/adapt/SKILL.md
+++ b/skills/adapt/SKILL.md
@@ -37,7 +37,7 @@ Do NOT proceed until both frameworks are present.
 > ```
 > Then run `/superpowers-gstack:adapt` again.
 
-**Version check:** This skill is version **1.8.1**. If the project's CLAUDE.md contains a version marker (`<!-- superpowers-gstack: X.Y.Z -->`) with an older version, inform the user that routing and session rules will be updated to the current version as part of this adaptation.
+**Version check:** This skill is version **1.9.0**. If the project's CLAUDE.md contains a version marker (`<!-- superpowers-gstack: X.Y.Z -->`) with an older version, inform the user that routing and session rules will be updated to the current version as part of this adaptation.
 
 ## Process
 

--- a/skills/macos-native-review/SKILL.md
+++ b/skills/macos-native-review/SKILL.md
@@ -1,0 +1,326 @@
+---
+name: macos-native-review
+description: Use after a PRD, spec, or implementation plan for a macOS app or feature — before implementation begins. Validates the artifact against Apple Human Interface Guidelines via WebFetch citations: vocabulary, control choices, keyboard shortcuts, semantic colors, sheets/popovers/alerts, animations, privileged operations, accessibility, menu bar, app lifecycle, dock behavior, App menu. Complementary to pitfall-verification ("will this work?") and quality-review ("will this feel good?") — this asks "is this Apple-native?".
+---
+
+# macOS native review
+
+Use this skill after a PRD, spec, or implementation plan that contains macOS-specific UI surfaces — before implementation begins. It is NOT a bug hunt, NOT a cross-platform polish review. It is a targeted check that *the artifact, if shipped as written, will read as a native Mac app to an experienced Mac user* — on the level of Things, Raycast, Linear-mac, Stripe-mac, CleanMyMac — and not as an iOS port.
+
+Every finding cites a specific Apple Human Interface Guidelines page on `developer.apple.com`. The model fetches HIG pages during review rather than relying on training-data recall, so verdicts are grounded in the current published guidelines.
+
+Invoke with: `/superpowers-gstack:macos-native-review`
+
+## When to invoke
+
+Automatically after completing:
+
+- A PRD, spec, or design document for a macOS app or feature
+- An implementation plan that touches macOS UI surfaces
+- Output from `writing-specs`, `writing-plans`, `plan-design-review`, `plan-eng-review`, or any planning skill — when macOS signals are present (see Phase 0)
+
+Run **once** before implementation. Re-run after substantial spec/plan revisions affecting UI surfaces.
+
+## Relationship to pitfall-verification and quality-review
+
+This skill is *complementary, not overlapping*, with the two existing review skills. Run all three sequentially on a fresh artifact for a macOS app:
+
+| Skill | Lens | Question |
+|-------|------|----------|
+| `pitfall-verification` | Correctness | "Will this work?" (bugs, security, contracts, edge cases) |
+| `quality-review` | Perceived quality | "Will this feel good?" (silent failures, loading, empty/error states, polish — cross-platform) |
+| `macos-native-review` | Apple-native conformance | "Is this Apple-native?" (HIG-citation-grounded, macOS-specific) |
+
+Recommended flow on a fresh artifact for a macOS app:
+
+1. `pitfall-verification` → fix bugs
+2. `quality-review` → fix feel
+3. `macos-native-review` → fix native-conformance gaps
+4. Hand off to `writing-plans` / implementation
+
+`macos-native-review` does *not* replace `quality-review`. The latter has 13 platform-independent categories (silent failures, empty states, multi-tenancy, AI output, sort order, etc.) that are still worth running on macOS projects. Modest overlap on two categories (quality-review's keyboard / animations) is acceptable: that skill checks generic conventions, this skill checks Apple-specific values.
+
+## Sequence
+
+1. **Phase 0 — macOS signal detection** (~30 seconds). Scan the artifact for macOS signals. If none found, return `N/A` and exit. If iOS-only, return `N/A` with deferred-skill note. Otherwise proceed.
+2. **Walk the 12 categories.** For each: question → risk surface → verify against HIG page (WebFetch) → cite → report `N/A | HANDLED | NOT HANDLED — proposed fix`.
+3. **Produce the verdict** in the output format below.
+
+## Phase 0 — macOS signal detection
+
+Scan the artifact for any of these signals:
+
+- `.swift` files referenced in scope
+- Imports: `SwiftUI`, `AppKit`, `Cocoa`, `Combine` (in Apple context)
+- Type references: `NSWindow`, `NSView`, `NSApplication`, `NSDocument`, `WindowGroup`, `MenuBarExtra`, `Settings` scene
+- Explicit text: "macOS app", "Mac app", "macOS-native", "AppKit", "SwiftUI for Mac"
+- Build target: `.xcodeproj` with macOS deployment target, `Package.swift` with `.macOS(.v…)` platform
+
+Decision:
+
+- **No signals found:** return `N/A — no macOS surfaces detected, skill not applicable` and exit. Do not proceed.
+- **Multi-target (iOS + macOS):** proceed. macOS surfaces are relevant.
+- **iOS-only signals:** return `N/A — iOS-only project. The ios-native-review skill is in the backlog (IDEAS.md). Run /quality-review for cross-platform polish in the meantime.`
+- **macOS signals present:** proceed.
+
+Phase 0 is the safety net for false positives. Without it, the skill would flag "missing ⌘ shortcuts" for a Linux CLI tool.
+
+## Category-default HIG URL table
+
+Output this table at the top of every review. Each finding cites either the default URL or a more specific sub-page.
+
+| # | Category | Default HIG URL |
+|---|----------|------------------|
+| 1 | Vocabulary | (cross-referenced per-component — cites the HIG page of the component containing the offending text) |
+| 2 | Buttons & control choices | https://developer.apple.com/design/human-interface-guidelines/buttons |
+| 3 | Keyboard shortcuts | https://developer.apple.com/design/human-interface-guidelines/keyboards |
+| 4 | Semantic colors & dark mode | https://developer.apple.com/design/human-interface-guidelines/color, https://developer.apple.com/design/human-interface-guidelines/dark-mode |
+| 5 | Sheets, popovers, alerts | https://developer.apple.com/design/human-interface-guidelines/sheets, https://developer.apple.com/design/human-interface-guidelines/popovers, https://developer.apple.com/design/human-interface-guidelines/alerts |
+| 6 | Animation timing | https://developer.apple.com/design/human-interface-guidelines/motion |
+| 7 | Privileged operations & permission prompts | https://developer.apple.com/design/human-interface-guidelines/privacy |
+| 8 | Accessibility | https://developer.apple.com/design/human-interface-guidelines/accessibility |
+| 9 | Menu bar | https://developer.apple.com/design/human-interface-guidelines/the-menu-bar |
+| 10 | App lifecycle & window restoration | https://developer.apple.com/design/human-interface-guidelines/windows, https://developer.apple.com/design/human-interface-guidelines/the-menu-bar |
+| 11 | Dock icon behavior (Apple HIG has no standalone Dock page; default URL covers Dock contextual menus only — see citation note in §11 below) | https://developer.apple.com/design/human-interface-guidelines/dock-menus |
+| 12 | App menu (App > About / Settings… / Quit) | https://developer.apple.com/design/human-interface-guidelines/the-menu-bar |
+
+URLs verified at skill creation. If a URL 404s during review, see "Fallback when developer.apple.com unreachable" below.
+
+## The 12 categories
+
+For each category: state the question, locate the risk surface in the artifact, verify by WebFetching the HIG page, and report `N/A | HANDLED | NOT HANDLED — proposed fix` with citation.
+
+### 1. Vocabulary
+
+Does copy use Apple-canonical verbs and noun choices? In macOS 13+, "Settings" replaced "Preferences" as the App-menu label. Apple uses `Apply` / `Replace` / `Save` / `Done` / `Cancel`, not custom verbs. Apple says "Sidebar", not "Navigation Pane"; "Sheet", not "Modal Dialog". Vocabulary mismatches signal "this app doesn't know the platform".
+
+Risk surfaces: every user-facing string in the spec (button labels, menu items, dialog titles, error messages, empty-state copy).
+
+Cite: the HIG page of the component containing the offending text.
+
+### 2. Buttons & control choices
+
+Is the chosen control HIG-correct for the surface? Specifically: `Picker` vs `SegmentedControl` vs `TabView`; `Sheet` vs `Popover` vs `Alert`; toolbar buttons vs inline buttons; `Toggle` vs checkbox-styled button. A Picker used where a Segmented Control belongs reads as iOS-port instantly.
+
+Risk surfaces: every interactive control introduced by the spec.
+
+Cite: https://developer.apple.com/design/human-interface-guidelines/buttons (or sub-pages for specific control types).
+
+### 3. Keyboard shortcuts
+
+Are macOS-standard shortcuts present and correctly assigned?
+
+- ⌘W — close window (not quit)
+- ⌘Q — quit application
+- ⌘. — cancel current operation
+- ⌘1–9 — switch tabs / sidebar items
+- ⌘↩ — primary action in sheet
+- Space — quick-look / preview / expand-collapse
+- Esc — dismiss sheet / cancel
+
+Missing shortcuts = experienced Mac users hit phantom keys and feel the app is broken.
+
+Risk surfaces: every modal, sheet, list, navigation control in the spec.
+
+Cite: https://developer.apple.com/design/human-interface-guidelines/keyboards
+
+### 4. Semantic colors & dark mode
+
+Are status indicators using Apple semantic colors (`Color.accentColor`, `.red`, `.green`, `Color(NSColor.systemBlue)`) that adapt to appearance, or are they hardcoded hex? Does the spec address dark mode explicitly, or assume light-mode-only?
+
+Risk surfaces: every color reference in the spec; every status indicator; the dark-mode story (or its absence).
+
+Cite: https://developer.apple.com/design/human-interface-guidelines/color and /dark-mode.
+
+### 5. Sheets, popovers, alerts
+
+For each modal surface in the spec: is it the right type? Sheets are for window-scoped modal flows; popovers for transient inline content tied to a UI element; alerts for critical decisions. Is the dismiss mechanism HIG-compliant (sheet: dedicated Cancel + primary buttons; popover: click-outside; alert: Cancel + destructive action)? Is resize-ability appropriate?
+
+Risk surfaces: every modal or transient surface.
+
+Cite: /sheets, /popovers, /alerts.
+
+### 6. Animation timing
+
+Does the spec rely on SwiftUI default animations (`.easeInOut` — generic and reads as "default"), or specify named easing aligned with Apple's defaults (`.spring(response: 0.35, dampingFraction: 0.85)`, `.snappy`, `.smooth`)? Premium Mac apps have signature motion. Generic `.easeInOut` reads as "AI-generated".
+
+Risk surfaces: every sheet present/dismiss, list reorder, state change that is visible.
+
+Cite: https://developer.apple.com/design/human-interface-guidelines/motion
+
+### 7. Privileged operations & permission prompts
+
+If the app requires sudo, admin auth, or system permissions (Full Disk Access, Accessibility, Screen Recording, Automation): is the flow framed as deliberate design — explanation sheet + consent + clear "why we need this" — or as a toast that pops up and disappears? "Just a toast" reads as cheap. Apple's HIG mandates explanation before the system prompt fires.
+
+Risk surfaces: every TCC permission, `osascript` with admin privileges, `Authorization Services` call, sudo flow.
+
+Cite: https://developer.apple.com/design/human-interface-guidelines/privacy
+
+### 8. Accessibility
+
+Are VoiceOver labels defined for non-text controls? Is Dynamic Type support implied (no fixed font sizes that break at large accessibility text sizes)? Is contrast adequate? Is full-keyboard-access mentioned for non-trivial flows?
+
+Risk surfaces: every interactive control, every text-density spec, every keyboard-flow.
+
+Cite: https://developer.apple.com/design/human-interface-guidelines/accessibility
+
+### 9. Menu bar
+
+Does the spec define a menu bar? At minimum macOS apps need: App menu (auto), File, Edit, View (if applicable), Window, Help. Are commands placed in HIG-conventional menus (e.g., Find in Edit, not in View)? Are in-menu shortcuts annotated? Missing menu bar = experienced Mac user looks for the keyboard equivalent and finds nothing.
+
+Risk surfaces: any spec describing a Mac app's command surface; any feature that should be reachable via the menu bar.
+
+Cite: https://developer.apple.com/design/human-interface-guidelines/the-menu-bar
+
+### 10. App lifecycle & window restoration
+
+Is `⌘Q` vs `⌘W` semantics correct (Q quits app, W closes window only)? Does the spec address "close last window doesn't quit on Mac" (unlike iOS, the app stays running)? Is state restoration on relaunch defined ("Reopen All Windows from Last Session")? Is multi-window support indicated where relevant?
+
+Risk surfaces: app launch flow; quit/close flow; window-management behavior in spec.
+
+Cite: /windows, /the-menu-bar.
+
+### 11. Dock icon behavior
+
+Does click-on-dock-icon (when app is hidden / in background) reactivate the main window? Is a dock menu defined for relevant commands? Are badge counts used (and HIG-conformant) where appropriate?
+
+Risk surfaces: dock-icon UX; background/foreground transitions; dock contextual menu.
+
+Cite — citation strategy for this category:
+- For findings about Dock **right-click contextual menus** specifically: cite https://developer.apple.com/design/human-interface-guidelines/dock-menus.
+- For findings about general Dock UX (click-to-reactivate, badge counts, background/foreground transitions): Apple HIG does not have a single canonical page. Cite https://developer.apple.com/design/human-interface-guidelines/the-menu-bar (macOS-chrome guidance) or the relevant per-component page (e.g. notifications for badge counts).
+- If the citation is partial-match, note that explicitly in the finding (e.g. `Cited (partial — covers contextual menu only): <url>`).
+
+This is the only category in the skill where the default URL is a partial match. All other categories have a single canonical HIG page.
+
+### 12. App menu (App > About / Settings… / Quit)
+
+Does the spec include a proper App menu? It should have: About <App>, Settings… (not "Preferences" since macOS 13), Hide / Hide Others / Show All, Quit <App>. Is the About panel content specified (version, build, copyright, credits)?
+
+Risk surfaces: App menu structure; About panel content.
+
+Cite: https://developer.apple.com/design/human-interface-guidelines/the-menu-bar
+
+## How to run the check
+
+For each category:
+
+1. **State the question** — one sentence.
+2. **Locate the risk surface** — which spec section, which file, which user flow?
+3. **WebFetch the cited HIG page** — read the relevant guidance, capture a short verbatim quote (~10–25 words) that supports or contradicts the spec's choice.
+4. **Verify against the spec** — does the spec align with the HIG quote? Or does it deviate without rationale?
+5. **Compare to peer Mac apps** — when in doubt: "how does Things handle this?", "how does Raycast handle this?", "how does Stripe-mac handle this?". Cite the comparison.
+6. **Report**: `N/A` (with reason) / `HANDLED` (point to where) / `NOT HANDLED — proposed fix` (concrete, file/section-anchored, with citation).
+
+Concrete findings only. Never vague advice like "follow HIG more closely". Every NOT HANDLED finding must include:
+
+- A proposed fix that names a file, function, or spec section
+- A citation: HIG URL + verbatim quote
+
+### Citation discipline
+
+**Every finding cites a HIG URL.** No exceptions. Use the category-default URL or a more specific sub-page. Where the model is uncertain, WebFetch first, cite the exact quote, then form the finding.
+
+### Fallback when developer.apple.com unreachable
+
+If WebFetch fails for any HIG URL during review, the skill degrades visibly:
+
+- Each uncited finding is tagged `(uncited — developer.apple.com unreachable)`.
+- The verdict downgrades from `SHIP-READY` / `NEEDS PATCH` / `NEEDS POLISH` to `PROVISIONAL — re-run when network available`.
+
+Never fall back silently to training-data recall pretending the citation was verified.
+
+**Robust-citation note:** Apple's HIG site is a JS-rendered SPA. WebFetch sometimes returns minimal HTML. As a fallback, Apple exposes a structured-content JSON API at `https://developer.apple.com/tutorials/data/design/human-interface-guidelines/<slug>.json` that returns the page's content in machine-readable form. If WebFetch returns sparse content, retry against the JSON endpoint before tagging the finding as `(uncited)`.
+
+## Output format
+
+```
+macOS native review (HIG-citation-grounded) —
+
+CATEGORY-DEFAULT URLs:
+- [reproduce the 12-row table from above]
+
+CRITICAL (will feel un-Mac on first launch):
+- C<N>. <one-line finding> — <risk surface, file:line or spec section>
+  → <concrete fix anchored to a file/section>
+  Cited: <HIG URL> "<short verbatim quote>"
+- ...
+
+SIGNIFICANT (works, but reads as iOS-port within first week):
+- S<N>. <finding> → <fix>
+  Cited: <HIG URL> "<quote>"
+- ...
+
+POLISH (gap to Apple-tier — Things, Raycast, Linear-mac):
+- P<N>. <finding> → <fix>
+  Cited: <category-default URL> (or specific override)
+- ...
+
+Peer comparison: <which Mac-tier app was used as the bar — Things, Raycast, Linear-mac, Stripe-mac, CleanMyMac — and how this artifact stacks up>
+
+Verdict: SHIP-READY | NEEDS PATCH | NEEDS POLISH | PROVISIONAL
+```
+
+If `SHIP-READY`: hand off to implementation.
+If `NEEDS PATCH`: fix CRITICAL findings, re-run.
+If `NEEDS POLISH`: surface to user with explicit fix-now-or-defer choice (track deferred polish as debt note).
+If `PROVISIONAL`: communicate citation status; user decides whether to ship anyway or block on verification.
+
+## Severity rubric
+
+- **CRITICAL** — first launch reads as "wrong platform". Examples:
+  - `⌘Q` only closes active window instead of quitting the app
+  - "Settings" labeled "Preferences" or located outside the App menu
+  - No menu bar at all
+  - Modal sheet without a dismiss mechanism
+  - Hardcoded colors that fail completely in dark mode
+
+- **SIGNIFICANT** — works, but an experienced Mac user reads the app as an iOS port within the first week. Examples:
+  - Hardcoded colors that don't adapt to dark mode
+  - Generic SwiftUI-default `.easeInOut` on sheet present/dismiss
+  - Missing `⌘1–9` for tab switching
+  - `Picker` used where `Segmented Control` belongs
+  - Sudo prompt framed as toast instead of sheet with rationale
+
+- **POLISH** — the gap between "works as a Mac app" and "feels like Things, Raycast, Linear":
+  - No hover-state on toolbar buttons
+  - Animation timing close to but not exactly Apple's defaults
+  - About panel without copyright string or version-build label
+  - Missing menu-item shortcut hint where it could exist
+
+Be honest about severity. POLISH must not be escalated to CRITICAL to force fix.
+
+## What this skill is NOT
+
+- Not a bug hunt — that's `pitfall-verification`
+- Not a cross-platform polish review — that's `quality-review`
+- Not a security audit (entitlements, sandbox content) — that's `/cso`
+- Not a design review of an existing UI — that's `/design-review` (live) or `/plan-design-review` (plan)
+- Not a developer-experience review — that's `/plan-devex-review`
+- Not release engineering (code signing, notarization, Sparkle internals) — separate domain
+- Not iOS, iPadOS, watchOS, tvOS, visionOS — separate skills (deferred in IDEAS.md)
+- Not Windows or Android — separate skills (deferred in IDEAS.md)
+
+It is the *Apple-native conformance gate* between "spec written" and "implementation begins" for macOS projects. Catch the un-Mac decisions before they ship.
+
+## Example finding (tone & precision)
+
+```
+C1. App menu uses "Preferences" instead of "Settings". Spec §3.2 ("App
+menu structure") lists "Preferences…" as the App-menu item. Apple changed
+this label to "Settings…" in macOS 13 (Ventura, 2022); it is now canonical
+across the macOS ecosystem. Apps still using "Preferences…" read as
+un-updated.
+
+Risk surface: spec §3.2; whatever code generates the menu (likely
+`AppMenu.swift` or a SwiftUI `Settings` scene declaration).
+
+Fix: change spec §3.2 to "Settings…". When implementing, use SwiftUI's
+`Settings { }` scene which auto-labels the menu correctly on macOS 13+.
+
+Cited: https://developer.apple.com/design/human-interface-guidelines/the-menu-bar
+"In macOS 13 and later, the system uses the term Settings... to refer
+to what was formerly called preferences."
+```
+
+That is the bar: spec section reference, code-file pointer, concrete fix, and a verbatim HIG quote with URL.

--- a/skills/macos-native-review/SKILL.md
+++ b/skills/macos-native-review/SKILL.md
@@ -182,9 +182,9 @@ Cite: /windows, /the-menu-bar.
 
 ### 11. Dock icon behavior
 
-Does click-on-dock-icon (when app is hidden / in background) reactivate the main window? Is a dock menu defined for relevant commands? Are badge counts used (and HIG-conformant) where appropriate?
+Does click-on-dock-icon (when app is hidden / in background) reactivate the main window? Is a dock menu defined for relevant commands? Are badge counts used (and HIG-conformant) where appropriate? For menu-bar-only utilities (e.g. `MenuBarExtra`-only apps with no primary window), does the spec explicitly declare `LSUIElement` (Info.plist) — or the SwiftUI equivalent — to suppress the dock icon? An "agent app" that still shows a dock icon reads as un-finished.
 
-Risk surfaces: dock-icon UX; background/foreground transitions; dock contextual menu.
+Risk surfaces: dock-icon UX; background/foreground transitions; dock contextual menu; menu-bar-only apps that should be `LSUIElement` agents but don't say so.
 
 Cite — citation strategy for this category:
 - For findings about Dock **right-click contextual menus** specifically: cite https://developer.apple.com/design/human-interface-guidelines/dock-menus.

--- a/skills/macos-native-review/SKILL.md
+++ b/skills/macos-native-review/SKILL.md
@@ -300,6 +300,7 @@ Be honest about severity. POLISH must not be escalated to CRITICAL to force fix.
 - Not release engineering (code signing, notarization, Sparkle internals) — separate domain
 - Not iOS, iPadOS, watchOS, tvOS, visionOS — separate skills (deferred in IDEAS.md)
 - Not Windows or Android — separate skills (deferred in IDEAS.md)
+- Not a code-level SwiftUI review — that's `swiftui-expert-skill` by Antoine van der Lee (separate plugin, install via `/plugin install swiftui-expert@swiftui-expert-skill` after adding marketplace `AvdLee/SwiftUI-Agent-Skill`). It reviews SwiftUI implementation at the code layer (state management, view composition, performance, deprecated-API migration, Liquid Glass, Instruments tracing). `macos-native-review` reviews the spec/plan *before* code exists. Complementary at different lifecycle stages: run `macos-native-review` on the spec, then `swiftui-expert-skill` on the implementation.
 
 It is the *Apple-native conformance gate* between "spec written" and "implementation begins" for macOS projects. Catch the un-Mac decisions before they ship.
 

--- a/skills/setup-routing/SKILL.md
+++ b/skills/setup-routing/SKILL.md
@@ -39,7 +39,7 @@ Do NOT proceed until both frameworks are present.
 
 **Important:** If the project already has a `CLAUDE.md` file with existing content, STOP and suggest the user runs `/superpowers-gstack:adapt` instead — it preserves existing content while adding routing.
 
-**Version:** This skill writes version **1.8.1** into the CLAUDE.md version marker.
+**Version:** This skill writes version **1.9.0** into the CLAUDE.md version marker.
 
 ## Process
 


### PR DESCRIPTION
## Summary

Adds a new plugin-internal review skill, `/superpowers-gstack:macos-native-review`, that validates PRDs, specs, and implementation plans for macOS apps against Apple Human Interface Guidelines via WebFetch citations. 12 macOS-specific categories, severity-tiered findings, strict per-finding HIG URL citations, `PROVISIONAL` fallback when developer.apple.com is unreachable.

Sequential after `pitfall-verification` and `quality-review` for macOS artifacts:

| Skill | Lens | Question |
|-------|------|----------|
| `pitfall-verification` | Correctness | "Will this work?" |
| `quality-review` | Perceived quality | "Will this feel good?" |
| `macos-native-review` | Apple-native conformance | "Is this Apple-native?" |

Phase 0 self-check rejects non-macOS artifacts before category review (returns `N/A` for iOS-only or non-Apple projects).

Sibling skills (`ios-native-review`, `windows-native-review`, `material-design-review`) deferred as IDEAS.md backlog entries with a consistent template, shipped via this PR's IDEAS.md refactor.

## Provenance

- Brainstorming: in-session 2026-04-28 (5 question/answer rounds, A-A-B-A-B)
- Approved spec: `docs/superpowers/specs/2026-04-28-macos-native-review-design.md`
- Implementation plan: `docs/superpowers/plans/2026-04-28-macos-native-review-implementation.md`

## Test plan

- [x] Skill file is well-formed (frontmatter, 12 categories, 12-row default-URL table, output template, severity rubric, "What this skill is NOT")
- [x] All 12 default HIG URLs verified (12/13 OK as-is via curl + Apple JSON API; 1 substituted: `/the-dock` 404 → `/dock-menus` partial-match with citation-strategy note in §11)
- [x] Plugin version markers match across `plugin.json`, `setup-routing/SKILL.md`, `adapt/SKILL.md` (1.9.0)
- [x] README "What's Included" lists six skills, `macos-native-review` bullet matches the others' tone
- [x] CHANGELOG `[1.9.0]` entry voice matches prior entries
- [x] IDEAS.md: macOS proposal entry removed, three sibling stubs present, "Shipped" pointer at the bottom
- [x] Smoke test on synthetic 1-page macOS spec: would correctly produce `NEEDS PATCH` verdict (3 CRITICAL findings: ⌘W bound to Quit, sheet without Cancel, Preferences-vs-Settings); one gap surfaced and fixed inline (`LSUIElement` for menu-bar-only apps)
- [ ] Skill is discoverable in Claude Code skill list after `gh pr merge` and `/plugin update superpowers-gstack` (post-merge verification)

## Out of scope (deferred)

- iOS / Windows / Android sibling skills — backlog
- Adding `/macos-native-review` to user-level CLAUDE.md verification process — user's call
- Cross-references in `quality-review` / `pitfall-verification` to point at the new skill — separate change if value emerges in real use