### PR TITLE
docs(v1.9.1): integrate review skills into README workflow guidance

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "superpowers-gstack",
   "description": "Routing, context management, and project setup for the Superpowers + GStack workflow",
-  "version": "1.9.0",
+  "version": "1.9.1",
   "author": {
     "name": "Kjetil Geirbo"
   }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## [1.9.1] - 2026-04-29
+
+### Changed
+- **README workflow integration** — the three plugin-internal review skills (`/pitfall-verification`, `/quality-review`, `/macos-native-review`) were announced in v1.5.0, v1.8.0, and v1.9.0 in the "What's Included" section but never integrated into the README's workflow guidance. Result: users knew the skills existed but couldn't see where to invoke them in practice. This patch fixes that:
+  - **"The Workflow" 4-phase diagram** gains a new `PHASE 1.5: SPEC REVIEW (this plugin)` block between Phase 1 (planning) and Phase 2 (implementation).
+  - **"Common Scenarios → New Feature (Full Workflow)"** now shows the spec-review trio explicitly between `/plan-eng-review` and `/superpowers:brainstorming`, plus a `/pitfall-verification` re-check after `/superpowers:writing-plans`.
+  - **"Decision Tree"** gains a "Spec or plan written?" branch routing to the review trio before implementation.
+- `setup-routing` and `adapt` version markers bumped to 1.9.1.
+
+### Notes for users
+- No skill or behavior changes. Documentation-only patch addressing a discoverability gap surfaced after v1.9.0 shipped.
+
 ## [1.9.0] - 2026-04-28
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -110,6 +110,13 @@ This generates a CLAUDE.md with routing rules tailored to your project type, tec
 │  /plan-design-review → Design validation         │
 │  /autoplan        → Chains all three reviews     │
 ├─────────────────────────────────────────────────┤
+│  PHASE 1.5: SPEC REVIEW (this plugin)            │
+│                                                  │
+│  /pitfall-verification → "will this work?"       │
+│  /quality-review       → "will this feel good?"  │
+│  /macos-native-review  → "is this Apple-native?" │
+│                          (macOS projects only)   │
+├─────────────────────────────────────────────────┤
 │  PHASE 2: IMPLEMENTATION (Superpowers)           │
 │                                                  │
 │  /superpowers:brainstorming           → Refine   │
@@ -170,8 +177,13 @@ No hooks, no orchestration overhead, no nesting. Just save and restore.
 /plan-eng-review       → Lock architecture
   → Save key decisions to docs/
 /clear
+/pitfall-verification  → Spec-level: "will this work?"
+/quality-review        → Spec-level: "will this feel good?"
+[macOS only]
+/macos-native-review   → Spec-level: "is this Apple-native?"
 /superpowers:brainstorming         → Adopt design, refine technical approach
 /superpowers:writing-plans         → Break into TDD tasks
+/pitfall-verification  → Plan-level: re-check after writing-plans
 /superpowers:subagent-driven-development → Build it
 /clear
 /review                → Code review
@@ -235,6 +247,11 @@ New idea or feature?
     Scope clear?
       YES → /superpowers:brainstorming
       NO  → /office-hours
+
+Spec or plan written? (after writing-specs / writing-plans / plan-eng-review)
+  → /pitfall-verification → /quality-review
+  → [macOS] /macos-native-review
+  → /superpowers:writing-plans (or /superpowers:subagent-driven-development)
 
 Code written?  → /clear → /review
 Review feedback needs changes? → /superpowers:receiving-code-review → fix → /review

--- a/skills/adapt/SKILL.md
+++ b/skills/adapt/SKILL.md
@@ -37,7 +37,7 @@ Do NOT proceed until both frameworks are present.
 > ```
 > Then run `/superpowers-gstack:adapt` again.
 
-**Version check:** This skill is version **1.9.0**. If the project's CLAUDE.md contains a version marker (`<!-- superpowers-gstack: X.Y.Z -->`) with an older version, inform the user that routing and session rules will be updated to the current version as part of this adaptation.
+**Version check:** This skill is version **1.9.1**. If the project's CLAUDE.md contains a version marker (`<!-- superpowers-gstack: X.Y.Z -->`) with an older version, inform the user that routing and session rules will be updated to the current version as part of this adaptation.
 
 ## Process
 

--- a/skills/setup-routing/SKILL.md
+++ b/skills/setup-routing/SKILL.md
@@ -39,7 +39,7 @@ Do NOT proceed until both frameworks are present.
 
 **Important:** If the project already has a `CLAUDE.md` file with existing content, STOP and suggest the user runs `/superpowers-gstack:adapt` instead — it preserves existing content while adding routing.
 
-**Version:** This skill writes version **1.9.0** into the CLAUDE.md version marker.
+**Version:** This skill writes version **1.9.1** into the CLAUDE.md version marker.
 
 ## Process
 


### PR DESCRIPTION
## Summary

Documentation-only patch addressing a discoverability gap in the v1.9.0 release. The three plugin-internal review skills (`pitfall-verification`, `quality-review`, `macos-native-review`) were announced in "What's Included" across v1.5.0, v1.8.0, and v1.9.0 — but never threaded into the README's actual workflow guidance. Users could see the skills existed but couldn't see where to invoke them in practice.

## Changes

Three README sections updated:

1. **"The Workflow" diagram** — new `PHASE 1.5: SPEC REVIEW (this plugin)` block between Phase 1 (planning) and Phase 2 (implementation), showing the three review skills with their one-line questions.
2. **"Common Scenarios → New Feature (Full Workflow)"** — the spec-review trio now appears explicitly between `/plan-eng-review` and `/superpowers:brainstorming`, plus a `/pitfall-verification` re-check after `/superpowers:writing-plans`.
3. **"Decision Tree"** — new "Spec or plan written?" branch routing to the review trio before implementation.

Plus version-marker lockstep: `plugin.json` 1.9.0 → 1.9.1, `setup-routing/SKILL.md` and `adapt/SKILL.md` markers bumped to match.

## Out of scope

- No skill or behavior changes
- No changes to `Small Feature` / `Tiny Project` / `Bug Fix` / `Security-Critical Feature` scenarios — those flows intentionally skip spec-review, which is correct for their scale
- The review skills' frontmatter `description` already auto-triggers them in many cases; this PR just makes the recommendation explicit in the README so users don't depend on auto-trigger alone

## Test plan

- [x] `plugin.json` version 1.9.0 → 1.9.1
- [x] `setup-routing` and `adapt` version markers in lockstep
- [x] CHANGELOG `[1.9.1]` entry voice matches `[1.8.1]` (prior docs-only patch)
- [x] All three README sections render correctly (verified locally)