### PR TITLE
fix(v2.13.1): autoimplement Check 1 zsh portability

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "superpowers-gstack",
   "description": "Routing, context management, and project setup for the Superpowers + GStack workflow",
-  "version": "2.13.0",
+  "version": "2.13.1",
   "author": {
     "name": "Kjetil Geirbo"
   }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## [2.13.1] - 2026-05-26
+
+### Fixed
+
+- **autoimplement Check 1 zsh portability** — the bash snippet used bare
+  `status=...` assignment, but `status` is a read-only variable in zsh
+  (the default shell on macOS). When the agent ran the snippet, zsh
+  errored with `read-only variable: status` and Check 1 failed before
+  it could refuse cleanly. Fixed by prefixing local variables with
+  `git_` (`git_branch`, `git_status`) — self-documenting and
+  collision-free across bash and zsh. Caught during live dogfood
+  testing — the first real invocation of v2.13.0 surfaced this.
+
 ## [2.13.0] - 2026-05-25
 
 ### Added

--- a/docs/superpowers/plans/2026-05-25-autoimplement-skill-v2.md
+++ b/docs/superpowers/plans/2026-05-25-autoimplement-skill-v2.md
@@ -224,13 +224,15 @@ not proceed.
 ### Check 1: Workspace is on a feature branch with a clean tree
 
 ```bash
-branch=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "")
-status=$(git status --porcelain 2>/dev/null || echo "GIT_FAIL")
+git_branch=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "")
+git_status=$(git status --porcelain 2>/dev/null || echo "GIT_FAIL")
 ```
 
+(Variable names are deliberately prefixed `git_` — bare `status` is read-only in zsh, the default shell on macOS, which would break this snippet when the agent runs it via Bash. The `git_` prefix avoids the collision and is self-documenting.)
+
 Refuse if:
-- `branch` is empty, `main`, `master`, or `GIT_FAIL` → "autoimplement runs only on a feature branch in a git repo. You are on '<branch>'. Create a feature branch first; suggested name: `feat/<plan-slug>`."
-- `status` is non-empty → "working tree has uncommitted changes — autoimplement requires a clean tree (so phase commits are unambiguous). Commit or stash, then re-invoke."
+- `git_branch` is empty, `main`, `master`, or `GIT_FAIL` → "autoimplement runs only on a feature branch in a git repo. You are on '<branch>'. Create a feature branch first; suggested name: `feat/<plan-slug>`."
+- `git_status` is non-empty → "working tree has uncommitted changes — autoimplement requires a clean tree (so phase commits are unambiguous). Commit or stash, then re-invoke."
 
 ### Check 2: Phase count is at least 2
 

--- a/skills/autoimplement/SKILL.md
+++ b/skills/autoimplement/SKILL.md
@@ -45,13 +45,15 @@ not proceed.
 ### Check 1: Workspace is on a feature branch with a clean tree
 
 ```bash
-branch=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "")
-status=$(git status --porcelain 2>/dev/null || echo "GIT_FAIL")
+git_branch=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "")
+git_status=$(git status --porcelain 2>/dev/null || echo "GIT_FAIL")
 ```
 
+(Variable names are deliberately prefixed `git_` — bare `status` is read-only in zsh, the default shell on macOS, which would break this snippet when the agent runs it via Bash. The `git_` prefix avoids the collision and is self-documenting.)
+
 Refuse if:
-- `branch` is empty, `main`, `master`, or `GIT_FAIL` → "autoimplement runs only on a feature branch in a git repo. You are on '<branch>'. Create a feature branch first; suggested name: `feat/<plan-slug>`."
-- `status` is non-empty → "working tree has uncommitted changes — autoimplement requires a clean tree (so phase commits are unambiguous). Commit or stash, then re-invoke."
+- `git_branch` is empty, `main`, `master`, or `GIT_FAIL` → "autoimplement runs only on a feature branch in a git repo. You are on '<branch>'. Create a feature branch first; suggested name: `feat/<plan-slug>`."
+- `git_status` is non-empty → "working tree has uncommitted changes — autoimplement requires a clean tree (so phase commits are unambiguous). Commit or stash, then re-invoke."
 
 ### Check 2: Phase count is at least 2
 
@@ -333,6 +335,7 @@ autoimplement is a high-trust skill — when invoked, it executes plan phases wi
 | Plan v2 → codex review | codex (gpt-5.5) | 11 findings, 4 blockers | All addressed before implementation |
 | Code → pitfall | self | clean | — |
 | Code → codex review | codex (gpt-5.5) | 6 findings (2 P1, 3 P2, 1 P3) | All addressed before merge |
+| v2.13.1 → live dogfood | user (kjetilge) | 1 portability bug: bare `status=` assignment fails in zsh (read-only var) | Fixed: prefix `git_` on local vars |
 
 **Meta-review note:** As of v2.13.0, the pitfall-verification and codex-review skills themselves have not been independently audited for blind spots. This is a known limitation. If/when a `/audit-review-skills` skill exists, autoimplement should be re-reviewed under it. Until then, the chain `code → pitfall + codex` is considered adequate based on accumulated evidence that both surface real issues.
 


### PR DESCRIPTION
## Summary

First post-ship dogfood bug on v2.13.0. The Check 1 bash snippet used `status=...` as a local variable, which fails in zsh because `status` is the shell's read-only exit-code indicator.

```bash
# Old (zsh: read-only variable: status)
branch=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "")
status=$(git status --porcelain 2>/dev/null || echo "GIT_FAIL")

# New (zsh-safe)
git_branch=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "")
git_status=$(git status --porcelain 2>/dev/null || echo "GIT_FAIL")
```

## Why the pre-ship review chain missed it

3 rounds of pitfall + codex on plan, 1 round on code — all clean. Reviewers checked semantic correctness, not shell-portability of embedded snippets. This is a real gap worth noting for future skill review: **agents reading SKILL.md run bash via the Claude Code Bash tool, which inherits the user's $SHELL — zsh on macOS by default — not bash unconditionally.**

## Test plan

- [x] YAML frontmatter test passes
- [x] Required-sections test passes (32 anchors)
- [x] Manually verified: the new snippet runs cleanly in both bash and zsh
- [x] Plan v2 spec synced

## Merge

Use `--squash`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)