### PR TITLE
fix(v2.13.2): autoimplement fixture cross-run idempotency

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "superpowers-gstack",
   "description": "Routing, context management, and project setup for the Superpowers + GStack workflow",
-  "version": "2.13.1",
+  "version": "2.13.2",
   "author": {
     "name": "Kjetil Geirbo"
   }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,26 @@
 # Changelog
 
+## [2.13.2] - 2026-05-26
+
+### Fixed
+
+- **autoimplement fixture cross-run idempotency** — `tiny-plan.md` used
+  `grep -c '^phaseN$' == 1` for verify, which breaks on re-runs (appending
+  produces duplicate lines → count becomes 2 → verify fails). Caught by
+  codex review during v2.13.1 dogfood Phase 1 chain — a real cross-run bug
+  that neither `/review` nor `/pitfall-verification` flagged (they correctly
+  focus on single-diff correctness, not temporal/cross-run semantics).
+  Fix: switched to `grep -q` presence-check + explicit echo, making the
+  fixture idempotent across multiple runs on the same branch. Audit trail
+  in SKILL.md updated.
+
+### Notes
+
+- This is the second meta-finding validating cross-model adversarial value:
+  codex caught a bug single-shot reviewers structurally cannot see.
+  Documented in the autoimplement audit trail as evidence of the
+  pattern's practical value.
+
 ## [2.13.1] - 2026-05-26
 
 ### Fixed

--- a/docs/superpowers/plans/2026-05-25-autoimplement-skill-v2.md
+++ b/docs/superpowers/plans/2026-05-25-autoimplement-skill-v2.md
@@ -739,13 +739,13 @@ Create `skills/autoimplement/tests/fixtures/tiny-plan.md`:
 echo "phase1" >> skills/autoimplement/tests/fixtures/sample.txt
 ```
 
-- [ ] **Step 2: Verify**
+- [ ] **Step 2: Verify (idempotent — presence-check, not count)**
 
 ```bash
-grep -c '^phase1$' skills/autoimplement/tests/fixtures/sample.txt
+grep -q '^phase1$' skills/autoimplement/tests/fixtures/sample.txt && echo "phase1 present"
 ```
 
-Expected: `1`
+Expected: `phase1 present`
 
 - [ ] **Step 3: Commit**
 
@@ -769,13 +769,13 @@ git commit -m "test(autoimplement): tiny-plan phase 1 (e2e fixture)"
 echo "phase2" >> skills/autoimplement/tests/fixtures/sample.txt
 ```
 
-- [ ] **Step 2: Verify**
+- [ ] **Step 2: Verify (idempotent — presence-check, not count)**
 
 ```bash
-grep -c '^phase2$' skills/autoimplement/tests/fixtures/sample.txt
+grep -q '^phase2$' skills/autoimplement/tests/fixtures/sample.txt && echo "phase2 present"
 ```
 
-Expected: `1`
+Expected: `phase2 present`
 
 - [ ] **Step 3: Commit**
 

--- a/skills/autoimplement/SKILL.md
+++ b/skills/autoimplement/SKILL.md
@@ -336,6 +336,7 @@ autoimplement is a high-trust skill — when invoked, it executes plan phases wi
 | Code → pitfall | self | clean | — |
 | Code → codex review | codex (gpt-5.5) | 6 findings (2 P1, 3 P2, 1 P3) | All addressed before merge |
 | v2.13.1 → live dogfood | user (kjetilge) | 1 portability bug: bare `status=` assignment fails in zsh (read-only var) | Fixed: prefix `git_` on local vars |
+| v2.13.2 → full dogfood Phase 1 (review + pitfall + codex chain) | codex (gpt-5.5) caught 1 [P1] in fixture | Fixture's `grep -c == 1` verify breaks on re-runs (cross-run idempotency bug) | Fixed: `grep -q` presence-check makes fixture idempotent. Validates Step D's cross-model adversarial value — finding missed by /review and /pitfall, caught by codex. |
 
 **Meta-review note:** As of v2.13.0, the pitfall-verification and codex-review skills themselves have not been independently audited for blind spots. This is a known limitation. If/when a `/audit-review-skills` skill exists, autoimplement should be re-reviewed under it. Until then, the chain `code → pitfall + codex` is considered adequate based on accumulated evidence that both surface real issues.
 

--- a/skills/autoimplement/tests/fixtures/tiny-plan.md
+++ b/skills/autoimplement/tests/fixtures/tiny-plan.md
@@ -6,6 +6,8 @@
 
 **Architecture:** Trivial. Each phase has one task that runs `echo ... >> sample.txt && git add && git commit`. Exercises the real commit + review chain — not a /tmp fake.
 
+**Idempotency:** Verify steps use `grep -q` (presence check) instead of `grep -c == 1` (exact-count check). This makes the fixture safe to re-run on a branch that already ran it once — re-appending duplicates "phase1" but presence-check still succeeds. Caught by codex review during v2.13.0 dogfood (would have caused cross-run verification failures otherwise).
+
 **Tech Stack:** Bash + a tracked text file.
 
 ---
@@ -23,13 +25,13 @@
 echo "phase1" >> skills/autoimplement/tests/fixtures/sample.txt
 ```
 
-- [ ] **Step 2: Verify**
+- [ ] **Step 2: Verify (idempotent — presence-check, not count)**
 
 ```bash
-grep -c '^phase1$' skills/autoimplement/tests/fixtures/sample.txt
+grep -q '^phase1$' skills/autoimplement/tests/fixtures/sample.txt && echo "phase1 present"
 ```
 
-Expected: `1`
+Expected: `phase1 present`
 
 - [ ] **Step 3: Commit**
 
@@ -53,13 +55,13 @@ git commit -m "test(autoimplement): tiny-plan phase 1 (e2e fixture)"
 echo "phase2" >> skills/autoimplement/tests/fixtures/sample.txt
 ```
 
-- [ ] **Step 2: Verify**
+- [ ] **Step 2: Verify (idempotent — presence-check, not count)**
 
 ```bash
-grep -c '^phase2$' skills/autoimplement/tests/fixtures/sample.txt
+grep -q '^phase2$' skills/autoimplement/tests/fixtures/sample.txt && echo "phase2 present"
 ```
 
-Expected: `1`
+Expected: `phase2 present`
 
 - [ ] **Step 3: Commit**
 


### PR DESCRIPTION
## Summary

Codex review during v2.13.1 dogfood Phase 1 chain caught a [P1] cross-run idempotency bug in `tiny-plan.md`:

```bash
# Old (fails on re-run — count becomes 2)
grep -c '^phase1$' .../sample.txt
# Expected: 1

# New (idempotent — presence check)
grep -q '^phase1$' .../sample.txt && echo "phase1 present"
# Expected: phase1 present
```

## Why this matters (meta-validation)

Neither `/review` nor `/pitfall-verification` flagged this — both correctly focus on single-diff correctness. The bug only manifests *across runs* on the same branch, which neither skill is structurally designed to see.

Codex caught it because cross-model adversarial review uses a *different* mental model (independent context, no inherited assumptions). This is the second consecutive dogfood finding validating cross-model adversarial value:

1. v2.13.1: zsh portability (Check 1 `status=` collision) — caught by user dogfood
2. v2.13.2: cross-run fixture idempotency — caught by codex during dogfood

The autoimplement audit trail in SKILL.md now documents both as evidence of the pattern's practical value.

## Test plan

- [x] YAML frontmatter test passes
- [x] Required-sections test passes (32 anchors)
- [x] Fixture now safe to re-run on same branch (manually verified the grep -q behavior)

## Merge

Use `--squash`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)