### PR TITLE
plan-fidelity: rett planen i samme commit som avviket (2.35.0)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "superpowers-gstack",
   "description": "Routing, context management, and project setup for the Superpowers + GStack workflow",
-  "version": "2.34.1",
+  "version": "2.35.0",
   "author": {
     "name": "Kjetil Geirbo"
   }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,31 @@
 # Changelog
 
-## [2.34.1] - 2026-07-05
+## [2.35.0] - 2026-08-16
+
+New emitted block: **Keep the plan true to the code**. Closes a gap found while
+executing a plan in a real project — the plan described a design that was
+deliberately abandoned mid-work, and nothing in either framework asked for it to
+be corrected.
+
+### Added
+- `skills/setup-routing/blocks/plan-fidelity.md` (`gstack-plan-fidelity-v1`),
+  emitted by both generators for all tracks. The rule: when implementation
+  diverges from the plan, fix the plan **in the same commit as the divergence** —
+  replacing the superseded section rather than appending a correction under it,
+  and keeping the *reason* the draft was dropped, which is the part a future
+  reader cannot reconstruct. Names the three ways plans go stale (better approach
+  found, task done out of order, a measurement kills a premise) and states
+  explicitly that deleting an invalidated phase is allowed.
+
+### Why not leave this to `/ship`
+GStack's `/ship` already audits plan completion and has a `CHANGED` class for
+"implemented differently, same goal achieved". That is real detection — but it
+runs at merge time, writes its findings to the PR body rather than back into the
+plan, and never runs at all on a branch that is not shipped. The failure this
+block addresses happened hours before any ship gate, on a branch still in
+progress, while the plan was actively being read as instructions. The block says
+so, so nobody re-litigates the overlap.
+
 
 Fixes for the three findings of the second external audit round (Codex).
 

--- a/scripts/lint-skills.py
+++ b/scripts/lint-skills.py
@@ -70,6 +70,7 @@ MARKER_BLOCKS = [
     "git-hygiene.md",
     "multi-lens-review.md",
     "code-reuse.md",
+    "plan-fidelity.md",
     "track-routing.md",
     "xcode-tools.md",
     "companion-skills.md",

--- a/skills/adapt/SKILL.md
+++ b/skills/adapt/SKILL.md
@@ -270,6 +270,15 @@ The block to insert: read `blocks/multi-lens-review.md` (see **Shared block file
 
 The block to insert: read `blocks/code-reuse.md` (see **Shared block files** above) and insert its content verbatim.
 
+**Insert or upgrade the Keep the plan true to the code section.** This section applies to ALL projects (plan drift is not track-specific). Scan CLAUDE.md for heading `^#{2,3} Keep the plan true to the code` and its version marker `<!-- gstack-plan-fidelity-vN -->`. Apply the same four-case logic:
+
+1. **Heading present + marker matches `v1`** → skip (idempotent).
+2. **Heading present + marker present + different version** → REPLACE through next heading of equal-or-shallower level. Preserve original heading level. (The block has H3 subsections; "next heading" alone would stop at the first one and leave old prose behind.) **If the existing root is H3**, demote every subsection in the replacement one level (H3 → H4) so subsections do not sit at the same level as the root — same demote requirement as case 4.
+3. **Heading present + marker absent** → REPLACE the same way; one-time silent upgrade adds the current marker. (Unlike Code reuse, this heading is specific enough that a user-authored collision is implausible.)
+4. **Heading absent** → APPEND the block below as H2 (subsections stay at H3, one level below the root). If you instead insert it under `## Skill routing` as H3, you MUST demote every H3 subsection to H4 — otherwise the next marker upgrade stops at the first subsection and leaves stale content behind.
+
+The block to insert: read `blocks/plan-fidelity.md` (see **Shared block files** above) and insert its content verbatim.
+
 **Preserve or upgrade existing Track-aware routing.** Before
 inserting the Track-aware routing section, scan the project's
 CLAUDE.md. Check two things independently: (a) does any heading

--- a/skills/setup-routing/SKILL.md
+++ b/skills/setup-routing/SKILL.md
@@ -281,9 +281,10 @@ verbatim, in this order:
   2. `blocks/git-hygiene.md`
   3. `blocks/multi-lens-review.md`
   4. `blocks/code-reuse.md`
-  5. `blocks/track-routing.md`
-  6. `blocks/xcode-tools.md` — ONLY when `.gstack/track` is `ios`, `macos`, or `both`; skip for web
-  7. `blocks/companion-skills.md` — same native-track condition as xcode-tools.md
+  5. `blocks/plan-fidelity.md`
+  6. `blocks/track-routing.md`
+  7. `blocks/xcode-tools.md` — ONLY when `.gstack/track` is `ios`, `macos`, or `both`; skip for web
+  8. `blocks/companion-skills.md` — same native-track condition as xcode-tools.md
 Resolve `{{...}}` placeholders per `blocks/PLACEHOLDERS.md` before writing — never
 let a raw `{{...}}` token reach the generated CLAUDE.md. If the `blocks/` directory
 is missing (older plugin cache), warn the user to run `/plugin update

--- a/skills/setup-routing/blocks/plan-fidelity.md
+++ b/skills/setup-routing/blocks/plan-fidelity.md
@@ -1,0 +1,27 @@
+## Keep the plan true to the code <!-- gstack-plan-fidelity-v1 -->
+
+When implementation diverges from the plan, **fix the plan in the same commit as the divergence.** Not at the end, not at `/ship`, not "later".
+
+A plan that describes something nobody built is worse than no plan: the next agent reads it as instructions and implements the abandoned design. Being out of date is passive; being confidently wrong is active harm.
+
+### The three ways a plan goes stale
+
+1. **Better approach found.** You read the existing code and the planned design turns out to be unnecessary or wrong. This is a *good* outcome — but the plan must now say what was built and why the draft was dropped.
+2. **Task done out of order.** The user reports a bug that a later phase covers, so you do it now. Mark it done and note why the order changed.
+3. **A measurement kills a premise.** The plan's reasoning rested on an assumption; you measured, and it was false. Record the number you measured, not just "this turned out differently".
+
+### What to write
+
+Replace the superseded section — do not append a correction below it. Someone skimming reads the first plausible thing they find.
+
+- Mark the task `✅ LEVERT <commit-sha>` and state, in one or two sentences, how the built thing differs from the draft
+- Keep the *reason* the draft was dropped. That is the part a future reader cannot reconstruct
+- If part of the draft is still worth doing, move it to an explicit "deferred" note **with a trigger** — what would make it urgent — rather than leaving it inline as if it were planned work
+
+### Deleting is allowed
+
+If a whole phase is invalidated, say so at the top of that phase and stop maintaining its tasks. A struck-through phase with one honest sentence beats five obsolete task descriptions kept alive out of politeness to the draft.
+
+### Why this is not the ship gate's job
+
+`/ship` audits plan completion and classifies each item (`DONE` / `PARTIAL` / `CHANGED` / …), which is real and useful — but it runs at merge time, writes its findings to the PR body rather than back into the plan, and never runs at all on a branch that is not shipped. Divergence happens hours earlier, while the plan is still being read. Fix it there.


### PR DESCRIPTION
## Hva

Ny delt CLAUDE.md-blokk, `skills/setup-routing/blocks/plan-fidelity.md`
(`gstack-plan-fidelity-v1`), emittert av begge generatorene for alle tracks.

Regelen: **når implementasjonen avviker fra planen, rettes planen i samme commit
som avviket.**

## Hvorfor

Funnet under ekte planutførelse i et Swift-prosjekt. Planen beskrev en
`WaveformBarLayout` med nedskalering. Under implementeringen viste det seg at
macOS-siden allerede hadde riktig geometri, så riktig grep var å *dele* den i
stedet for å bygge noe nytt — et bedre utfall enn planen foreslo.

Men planen ble stående og beskrive det forkastede designet, komplett med
testkode. En framtidig agent som fulgte den lojalt ville implementert noe annet
enn det som ligger i repoet. Ingenting i verken Superpowers eller GStack ba om at
dokumentet ble rettet.

En plan som er utdatert er passiv. En plan som beskriver noe ingen bygde er aktivt
villedende.

## Hva blokken sier

- Erstatt den forkastede seksjonen — **ikke** legg en korreksjon under den. Den
  som skummer leser det første plausible hen finner.
- Behold **grunnen** til at utkastet ble forlatt. Det er den eneste delen en
  framtidig leser ikke kan rekonstruere fra koden.
- Er en hel fase ugyldiggjort: si det, og slutt å vedlikeholde oppgavene under.
- Navngir de tre måtene planer blir foreldet på: bedre tilnærming funnet, oppgave
  gjort ut av rekkefølge, og en måling som avliver en premiss.

## Hvorfor ikke overlate dette til `/ship`

GStacks `plan-completion.md` har allerede en `CHANGED`-klasse for «implementert
annerledes, samme mål oppnådd». Det er ekte deteksjon, og god.

Men den kjører ved merge, skriver funnene til PR-beskrivelsen i stedet for tilbake
i planen, og kjører ikke i det hele tatt på en gren som aldri shippes. Avviket
dette lukker skjedde timer før noen ship-gate, på en gren fortsatt i arbeid, mens
planen aktivt ble lest som instruks.

Blokken sier dette selv, så overlappet ikke blir diskutert på nytt av neste som
leser begge.

## Release-gate

- `python3 scripts/lint-skills.py` → **0 errors**, 1 warning (`W2
  swiftui-design-consultation` 851 linjer — eksisterende, urørt av denne PR-en)
- `./tests/run.sh` → alle suiter grønne
- Versjon 2.34.1 → **2.35.0**, CHANGELOG-oppføring lagt til
- Ingen ny skill ⇒ README og routing uendret (linten bekrefter)
- E8 tilfredsstilt: blokka er registrert i `MARKER_BLOCKS`, bærer sentinelen på
  H2-linja, og refereres fra **begge** generatorene

🤖 Generated with [Claude Code](https://claude.com/claude-code)